### PR TITLE
improve `coverage`

### DIFF
--- a/kartograf/coverage.py
+++ b/kartograf/coverage.py
@@ -10,7 +10,7 @@ def coverage(map_file, ip_list_file):
     rpki_nets = []
     rpki_masks = []
     for line in map_file:
-        pfx, asn = line.split(" ")
+        pfx, asn = line.split()
         ipn = ipaddress.ip_network(pfx)
         netw = int(ipn.network_address) # W: Constant name "netw" doesn't conform to UPPER_CASE naming style
         mask = int(ipn.netmask)
@@ -25,11 +25,10 @@ def coverage(map_file, ip_list_file):
         ip = int(ipaddress.ip_address(line.rstrip('\n')))
         addrs.append(ip)
 
-    df = pd.DataFrame()
-    df['ADDRS'] = addrs
+    df = pd.DataFrame({'ADDRS': addrs})
 
     def check_coverage(addr):
-        cov_list = addr & net_masks == network_addresses
+        cov_list = (addr & net_masks) == network_addresses
 
         if np.any(cov_list):
             return 1
@@ -39,7 +38,7 @@ def coverage(map_file, ip_list_file):
     df['COVERED'] = df.ADDRS.progress_apply(check_coverage)
     df_cov = df[df.COVERED == 1]
 
-    covered = len(df_cov.index)
-    total = len(df.index)
+    covered = len(df_cov)
+    total = len(df)
     percentage = (covered / total) * 100
     print(f"A total of {covered} IPs out of {total} are covered by the map. That's {percentage:.2f}%")


### PR DESCRIPTION
1. Replace `split(" ")` to `split()` to avoid redundance

2. Use `DataFrame` constructor

3. Add (addr & net_masks) to ensure the bitwise AND operation is evaluated before the comparison with `network_addresses`

4. There is no need to use `len` with `.index`, their length can be got directly