### PR TITLE
add shell.nix, including rpki-client package

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+{pkgs ? import <nixpkgs> {}}:
+
+let
+    rpki-client = import (builtins.fetchGit {
+        url = "https://github.com/fjahr/rpki-client-nix.git";
+        rev = "9d1c2e8bcaf15eff425385ab6494eac195434cc9";
+    }) {};
+in
+pkgs.mkShell {
+  packages = [
+    rpki-client
+    (pkgs.python3.withPackages (ps: [
+      ps.pandas
+      ps.beautifulsoup4
+      ps.requests
+      ps.tqdm
+    ]))
+  ];
+}


### PR DESCRIPTION
Little nix shell for working with kartograf -- not meant to build a package or be reproducible or anything, just convenience. 
Includes the [rpki-client-nix](https://github.com/fjahr/rpki-client-nix) package. 
