### PR TITLE
Add nix support for added pandarallel

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,30 @@
     # Build for all default systems: ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"]
     utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
+
+      # Custom derivation for pandarallel
+      pandarallel = pkgs.python3Packages.buildPythonPackage rec {
+        pname = "pandarallel";
+        version = "1.6.5";
+
+        src = pkgs.python3Packages.fetchPypi {
+          inherit pname version;
+          sha256 = "HC35j/ZEHorhP/QozuuqfsQtcx9/lyxBzk/e8dOt9kA=";
+        };
+
+        propagatedBuildInputs = with pkgs.python3Packages; [ pandas dill psutil ];
+
+        meta = with pkgs.lib; {
+          description = "An efficient parallel computing library for pandas";
+          homepage = "https://github.com/nalepae/pandarallel";
+          license = licenses.bsd3;
+        };
+      };
+
     in rec {
+      packages = {
+        inherit pandarallel;
+      };
       # This flake exposes one attribute: a development shell
       # containing the rpki-client and the necessary Python env and packages to run kartograf.
       # To use, run 'nix develop' in the current directory.
@@ -30,6 +53,7 @@
               ps.beautifulsoup4
               ps.requests
               ps.tqdm
+              pandarallel
             ]))
           ];
       };


### PR DESCRIPTION
I have added parallelization of the merge process using `pandarallel` with the last commit in master. I have also attempted to add this to our `flake.nix` but so far I haven't been successful.

This is the package I am using (v 1.6.5): https://pypi.org/project/pandarallel/

It appears there is no nix pkg for this. So I tried to add it's build to our `flake.nix` directly. It appears to work but when I try to use kartograf in the `nix develop` shell it appears to not be available.

Could you please take a look at the approach and code @jurraca ? Thanks a lot!
