### PR TITLE
fix expression, bump to 3.11 to get pandarallel to work

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
         pname = "pandarallel";
         version = "1.6.5";
 
-        src = pkgs.python3Packages.fetchPypi {
+        src = pkgs.python311Packages.fetchPypi {
           inherit pname version;
           sha256 = "HC35j/ZEHorhP/QozuuqfsQtcx9/lyxBzk/e8dOt9kA=";
         };
@@ -37,10 +37,7 @@
         };
       };
 
-    in rec {
-      packages = {
-        inherit pandarallel;
-      };
+    in {
       # This flake exposes one attribute: a development shell
       # containing the rpki-client and the necessary Python env and packages to run kartograf.
       # To use, run 'nix develop' in the current directory.
@@ -48,13 +45,13 @@
           packages = [
             rpki-cli.defaultPackage.${system}
             # Python 3.10 with packages
-            (pkgs.python310.withPackages (ps: [
+            (pkgs.python311.withPackages (ps: [
               ps.pandas
               ps.beautifulsoup4
               ps.requests
               ps.tqdm
-              pandarallel
             ]))
+            pandarallel
           ];
       };
     });


### PR DESCRIPTION
Pandarallel wants python 3.11. If we just build the package and pass it to our environment the python interpreter can find it and run it. 
The `python31x.withPackages` construct is for packages that are already in Nixpkgs, so when it loads them it makes sure that it has the right version for all the packages and that they'll work. 
In this case, we just declare `pandarallel` with python 311 independently and pass it in. 

We could find a working version of pandarallel with 310 if needed but it would take more work. 
Bumping everything to 311 works though.