### PR TITLE
Add coordinated launch feature (-wait option)

### DIFF
--- a/kartograf/collectors/parse.py
+++ b/kartograf/collectors/parse.py
@@ -4,9 +4,10 @@ from kartograf.timed import timed
 
 @timed
 def parse_routeviews_pfx2as(context):
-    raw_file = f'{context.data_dir_collectors}pfx2asn.txt'
+    raw_file = f'{context.out_dir_collectors}pfx2asn.txt'
     clean_file = f'{context.out_dir_collectors}pfx2asn_clean.txt'
 
+    print("Cleaning " + raw_file)
     with open(raw_file, 'r') as raw, open(clean_file, 'w') as clean:
         lines = raw.readlines()
         for line in lines:

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timedelta
 import gzip
-import os
 import shutil
 import sys
 
@@ -65,14 +64,17 @@ def download(url, file):
         for chunk in response.iter_content(chunk_size=8192):
             gz.write(chunk)
 
-    print(f'Unzipping {url}')
+
+def extract(file, context):
+    gz_file = context.data_dir_collectors + file + ".gz"
+    file = context.out_dir_collectors + file
+
+    print(f'Unzipping {gz_file}')
     with gzip.open(gz_file, 'rb') as f_in:
         with open(file, 'wb') as f_out:
             shutil.copyfileobj(f_in, f_out)
 
-    os.remove(gz_file)
-
-    print(f'Formatting {url}')
+    print(f'Formatting {file}')
     with open(file, "r") as read:
         lines = read.readlines()
 
@@ -92,7 +94,17 @@ def fetch_routeviews_pfx2as(context):
     download(latest_link(PFX2AS_V4), v4_file)
     download(latest_link(PFX2AS_V6), v6_file)
 
-    out_file = f'{context.data_dir_collectors}pfx2asn.txt'
+
+def extract_routeviews_pfx2as(context):
+    v4_file_name = 'routeviews_pfx2asn_ip4.txt'
+    v6_file_name = 'routeviews_pfx2asn_ip6.txt'
+
+    extract(v4_file_name, context)
+    extract(v6_file_name, context)
+
+    v4_file = context.out_dir_collectors + v4_file_name
+    v6_file = context.out_dir_collectors + v6_file_name
+    out_file = f'{context.out_dir_collectors}pfx2asn.txt'
 
     with open(v4_file, 'r') as v4, \
             open(v6_file, 'r') as v6, \

--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -11,7 +11,10 @@ class Context:
 
         # The epoch is used to keep artifacts seperated for each run. This
         # makes cleanup and debugging easier.
-        utc_time_now = time.time()
+        if args.wait:
+            utc_time_now = args.wait
+        else:
+            utc_time_now = time.time()
         # Uncomment this random fixed date for testing purposes
         # time_now = datetime(2008, 10, 31)
 

--- a/kartograf/irr/fetch.py
+++ b/kartograf/irr/fetch.py
@@ -40,9 +40,15 @@ def fetch_irr(context):
 
         ftp.close()
 
-        if file_name.endswith(".gz"):
-            print("Extracting " + file_name)
-            with gzip.open(local_file_path, 'rb') as r:
-                extracted_file_path = local_file_path.rstrip(".gz")
-                with open(extracted_file_path, 'wb') as w:
-                    shutil.copyfileobj(r, w)
+
+def extract_irr(context):
+    for ftp_file in IRR_FILE_ADDRESSES:
+        _, ftp_file_path = ftp_file.split("/", 1)
+        _, file_name = ftp_file_path.rsplit("/", 1)
+        local_file_path = context.data_dir_irr + file_name
+        extracted_file_path = context.out_dir_irr + file_name.rstrip(".gz")
+
+        print("Extracting " + file_name)
+        with gzip.open(local_file_path, 'rb') as r:
+            with open(extracted_file_path, 'wb') as w:
+                shutil.copyfileobj(r, w)

--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -11,7 +11,7 @@ from kartograf.util import rir_from_str
 def parse_irr(context):
     irr_res = f"{context.out_dir_irr}irr_final.txt"
 
-    irr_files = [path for path in pathlib.Path(context.data_dir_irr).rglob('*')
+    irr_files = [path for path in pathlib.Path(context.out_dir_irr).rglob('*')
                  if os.path.isfile(path)
                  and (os.path.splitext(path)[1] != ".gz")]
 

--- a/kartograf/kartograf.py
+++ b/kartograf/kartograf.py
@@ -14,9 +14,10 @@ from kartograf.rpki.fetch import fetch_rpki_db, validate_rpki_db
 from kartograf.rpki.parse import parse_rpki
 from kartograf.sort import sort_result_by_pfx
 from kartograf.util import (
-    print_section_header,
     calculate_sha256,
-    check_compatibility
+    check_compatibility,
+    print_section_header,
+    wait_for_launch
 )
 
 
@@ -25,6 +26,15 @@ class Kartograf:
     def map(args):
         print_section_header("Start Kartograf")
         check_compatibility()
+
+        if args.wait:
+            wait_epoch = datetime.datetime.utcfromtimestamp(int(args.wait))
+            utc_wait_epoch = wait_epoch.replace(tzinfo=timezone.utc)
+            local_wait_epoch = utc_wait_epoch.astimezone()
+            print(f"Coordinated launch mode: Waiting until {args.wait} "
+                  f"({local_wait_epoch.strftime('%Y-%m-%d %H:%M:%S %Z')}) to "
+                  "launch mapping process.")
+            wait_for_launch(args.wait)
 
         # This is used to measure the overall runtime of the program
         start_time = time.time()

--- a/kartograf/kartograf.py
+++ b/kartograf/kartograf.py
@@ -5,9 +5,9 @@ import time
 
 from kartograf.context import Context
 from kartograf.coverage import coverage
-from kartograf.collectors.routeviews import fetch_routeviews_pfx2as
+from kartograf.collectors.routeviews import extract_routeviews_pfx2as, fetch_routeviews_pfx2as
 from kartograf.collectors.parse import parse_routeviews_pfx2as
-from kartograf.irr.fetch import fetch_irr
+from kartograf.irr.fetch import extract_irr, fetch_irr
 from kartograf.irr.parse import parse_irr
 from kartograf.merge import merge_irr, merge_pfx2as, general_merge
 from kartograf.rpki.fetch import fetch_rpki_db, validate_rpki_db
@@ -72,6 +72,7 @@ class Kartograf:
 
         if context.args.irr:
             print_section_header("Parsing IRR")
+            extract_irr(context)
             parse_irr(context)
 
             print_section_header("Merging RPKI and IRR data")
@@ -79,6 +80,7 @@ class Kartograf:
 
         if context.args.routeviews:
             print_section_header("Parsing Routeviews pfx2as")
+            extract_routeviews_pfx2as(context)
             parse_routeviews_pfx2as(context)
 
             print_section_header("Merging Routeviews and base data")

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -84,9 +84,11 @@ def general_merge(base_file, extra_file, extra_filtered_file, out_file):
           "included in the base file:\n")
     df_extra['INCLUDED'] = df_extra.INETS.parallel_apply(check_inclusion)
     df_filtered = df_extra[df_extra.INCLUDED == 0]
+    # We are stuck at the end of the progress bar after above finishes
+    print("\n")
 
     if extra_filtered_file:
-        print(f"\nFinished filtering! Originally {len(df_extra.index)} "
+        print(f"Finished filtering! Originally {len(df_extra.index)} "
               f"entries filtered down to {len(df_filtered.index)}")
         df_filtered.to_csv(extra_filtered_file,
                            sep=' ',

--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -1,6 +1,7 @@
 import hashlib
-import subprocess
 import re
+import subprocess
+import time
 
 
 def calculate_sha256(file_path):
@@ -65,3 +66,15 @@ def check_compatibility():
 
     except subprocess.CalledProcessError:
         raise Exception(exception_msg)
+
+
+def wait_for_launch(wait):
+    wait = int(wait)
+
+    while True:
+        current_time = time.time()
+
+        if current_time >= wait:
+            break
+
+        time.sleep(1)

--- a/run
+++ b/run
@@ -37,6 +37,9 @@ if __name__ == "__main__":
     parser_map.add_argument("-r", "--reproduce", type=str, default=None)
     parser_map.add_argument("-t", "--epoch", type=str, default=None)
 
+    # Waits until the provided epoch is reached before starting the map
+    parser_map.add_argument("-w", "--wait", type=str, default=None)
+
     # TODO:
     # Save the final output file in a different location that the default out
     # folder
@@ -81,6 +84,9 @@ if __name__ == "__main__":
         parser.error('--reproduce is required when --epoch is set.')
     elif not args.epoch and args.reproduce:
         parser.error('--epoch is required when --reproduce is set.')
+
+    if args.wait and args.reproduce:
+        parser.error('--reproduce is not compatible with --wait.')
 
     if args.command == "map":
         Kartograf.map(args)


### PR DESCRIPTION
This allows multiple contributors to launch the mapping process simultaneously which would hopefully result in mostly the same data for all of them, potentially even let some of them get the exact same result, improving confidence in the correctness of the data collected.

It is currently unclear how well this works, so it needs to be tested extensively.

Usage example:
```
$ ./run map -w=1702047310

--- Start Kartograf ---

Using rpki-client version 8.6.
Coordinated launch mode: Waiting until 1702047310 (2023-12-08 15:55:10 CET) to launch mapping process.
[waits...]
The epoch for this run is: 1702047310 (2023-12-08 14:55:10 UTC, local: 2023-12-08 15:55:10 CET)
```