### PR TITLE
deps: bump numpy to 1.26.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ brew install rpki-client
 
 #### Python dependencies
 
-Python versions 3.10 and 3.11 have both been tested with Kartograf.
+Python versions 3.10, 3.11 and 3.12 have been tested with Kartograf.
 
 You can use `pip3` to install required Python packages:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4==4.11.1
-numpy==1.24.1
+numpy==1.26.4
 pandas==1.5.3
 requests>=2.31.0
 tqdm==4.64.1


### PR DESCRIPTION
This was needed to use Python 3.12, otherwise numpy would fail to build with distutils related issues. Installing setuptools/other workarounds did not seem to suffice, (although I didn't spend a lot of time debugging). Not sure what your requirements are for changing deps, but things seemed to work. Have attached the final output as well.

```bash
./run map -rv

--- Start Kartograf ---

Kartograf version: 0.4.4
Warning: Kartograf has not been tested with rpki-client version 9 or higher.
The epoch for this run is: 1710324943 (2024-03-13 10:15:43 UTC, local: 2024-03-13 10:15:43 GMT)

--- Fetching RPKI ---

Downloaded TAL for AFRINIC to /Users/xxx/kartograf/data/1710324943/rpki/tals/afrinic.tal, file hash: 2838ef30ea27ce5705abf5f5adb131d8c35b1f50858338a2f3c84bb207c2fa35
Downloaded TAL for APNIC to /Users/xxx/kartograf/data/1710324943/rpki/tals/apnic.tal, file hash: 472e551f7c551c2e999e582b7c9437d3bee4900fe53afff62aeb28d4940ade94
Downloaded TAL for ARIN to /Users/xxx/kartograf/data/1710324943/rpki/tals/arin.tal, file hash: 4f6c1e456fe5ab468beac1495e57d99a1eeeaa4d9f9e34519eaf58857c21af48
Downloaded TAL for LACNIC to /Users/xxx/kartograf/data/1710324943/rpki/tals/lacnic.tal, file hash: d44bb9394ab009c8b53e5efebf2a1c9450bab61a27efe00de5a3e4587a3a2f6a
Downloaded TAL for RIPE to /Users/xxx/kartograf/data/1710324943/rpki/tals/ripe.tal, file hash: 59ca27ef93f23682749fcefe7c6d70fbc723343549ff9e4d3996acaff79817fb
Downloading RPKI Data, this may take a while.
Downloaded RPKI Data, hash sum: 46118be1f0178eb6b4a769480cedf2015f7c8d49bdeea8f20c8e64dacc52a077
...finished in 0:06:04.622833

--- Fetching Routeviews pfx2as ---

Downloading from https://publicdata.caida.org/datasets/routing/routeviews-prefix2as/2024/03/routeviews-rv2-20240311-1200.pfx2as.gz
Downloaded /Users/xxx/kartograf/data/1710324943/collectors/routeviews_pfx2asn_ip4.txt.gz, file hash: 94e9cd9a5c6bb6119517735c8da24dc2b2617001c458109b70df3853b29f69c7
Downloading from https://publicdata.caida.org/datasets/routing/routeviews6-prefix2as/2024/03/routeviews-rv6-20240311-1200.pfx2as.gz
Downloaded /Users/xxx/kartograf/data/1710324943/collectors/routeviews_pfx2asn_ip6.txt.gz, file hash: ccc5875b596800060578c8d9502d6ee74dee755f75b9fc6d2dbcdfc00cc6d78e
...finished in 0:00:04.839127

--- Validating RPKI ---

Validating RPKI ROAs
232736 raw RKPI ROA files found.
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 232736/232736 [37:11<00:00, 104.30it/s]
232736 RKPI ROAs validated and saved to /Users/xxx/kartograf/out/1710324943/rpki/rpki_raw.json, file hash: d75e464e23e7404128f17cbc939eb7ad3d9fc6c9daefcb3cc12864c4e587f535
...finished in 0:37:25.018669

--- Parsing RPKI ---

Parsing 232736 ROAs
Result entries written: 472743
Duplicates found: 60152
Invalids found: 33336
Incompletes: 0
Non-ROA files: 0
...finished in 0:01:01.841265

--- Parsing Routeviews pfx2as ---

Unzipping /Users/xxx/kartograf/data/1710324943/collectors/routeviews_pfx2asn_ip4.txt.gz
Formatting /Users/xxx/kartograf/out/1710324943/collectors/routeviews_pfx2asn_ip4.txt
Unzipping /Users/xxx/kartograf/data/1710324943/collectors/routeviews_pfx2asn_ip6.txt.gz
Formatting /Users/xxx/kartograf/out/1710324943/collectors/routeviews_pfx2asn_ip6.txt
Cleaning /Users/xxx/kartograf/out/1710324943/collectors/pfx2asn.txt
...finished in 0:02:18.384762

--- Merging Routeviews and base data ---

Parse base file to numpy arrays
Parse extra file to Pandas DataFrame
Filtering extra prefixes that were already included in the base file:
100.00% :::::::::::::::::::::::::::::::::::::::: |   119838 /   119838 |                                                                                                                                                                                                                                         100.00% :::::::::::::::::::::::::::::::::::::::: |   119838 /   119838 |                                                                                                                                                                                                                                         100.00% :::::::::::::::::::::::::::::::::::::::: |   119838 /   119838 |                                                                                                                                                                                                                                       100.00% :::::::::::::::::::::::::::::::::::::::: |   119838 /   119838 |                                                                                                                                                                                                                                         100.00% :::::::::::::::::::::::::::::::::::::::: |   119838 /   119838 |                                                                                                                                                                                                                                         100.00% :::::::::::::::::::::::::::::::::::::::: |   119838 /   119838 |                                                                                                                                                                                                                                       
100.00% :::::::::::::::::::::::::::::::::::::::: |   119838 /   119838 |                                                                                                                                                                                                                                       
100.00% :::::::::::::::::::::::::::::::::::::::: |   119837 /   119837 |                                                                                                                                                                                                                                       
100.00% :::::::::::::::::::::::::::::::::::::::: |   119837 /   119837 |                                                                                                                                                                                                                                       
100.00% :::::::::::::::::::::::::::::::::::::::: |   119837 /   119837 |                                                                                                                                                                                                                                       

Finished filtering! Originally 1198377 entries filtered down to 595978
Merging base file with filtered extra file
...finished in 0:43:13.799599

--- Sorting results ---

...finished in 0:00:09.108234

--- Finishing Kartograf ---

The SHA-256 hash of the result file is: a6f7d48136d8aa5fcdea24d1eca60909c63f4ae6bd3d970cd72809d158555093
Total runtime: 1:30:18.038241
```

[Result.zip](https://github.com/fjahr/kartograf/files/14587252/Result.zip)