### PR TITLE
Add NixOS module to facilitate scheduled runs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -38,6 +38,17 @@
           license = licenses.bsd3;
         };
       };
+      kartografDeps = [
+        rpki-cli.defaultPackage.${system}
+        (pkgs.python311.withPackages (ps: [
+          ps.pandas
+          ps.beautifulsoup4
+          ps.numpy
+          ps.requests
+          ps.tqdm
+          pandarallel
+        ]))
+      ];
 
     in {
       # This flake exposes the following attributes:
@@ -47,17 +58,7 @@
       # * A default/kartograf package 
       # * A NixOS module
       devShell = pkgs.mkShell {
-        packages = [
-          rpki-cli.defaultPackage.${system}
-          # Python 3.10 with packages
-          (pkgs.python311.withPackages (ps: [
-            ps.pandas
-            ps.beautifulsoup4
-            ps.requests
-            ps.tqdm
-          ]))
-          pandarallel
-        ];
+        packages = kartografDeps;
       };
       packages = {
         kartograf = pkgs.stdenv.mkDerivation { # not a python-installable package, so just manually copy files
@@ -65,17 +66,7 @@
           version = "1.0.0";
           src = ./.;
           nativeBuildInputs = [ pkgs.makeWrapper ];
-          buildInputs = with pkgs.python3Packages; [
-            rpki-cli.defaultPackage.${system}
-            pkgs.python3
-            # from requirements.txt
-            beautifulsoup4
-            numpy
-            pandas
-            requests
-            tqdm
-            pandarallel
-          ];
+          buildInputs = kartografDeps;
           propagatedBuildInputs = [ rpki-cli.defaultPackage.${system} ];
           buildPhase = ''
             mkdir -p $out/lib/kartograf

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -14,7 +14,7 @@ def merge_irr(context):
     irr_filtered_file = f'{context.out_dir_irr}irr_filtered.txt'
     out_file = f"{context.out_dir}merged_file_rpki_irr.txt"
 
-    general_merge(rpki_file, irr_file, irr_filtered_file, out_file)
+    general_merge(rpki_file, irr_file, irr_filtered_file, out_file, context.args.silent, context.args.workers)
     shutil.copy2(out_file, context.final_result_file)
 
 
@@ -32,12 +32,13 @@ def merge_pfx2as(context):
     rv_file = f'{context.out_dir_collectors}pfx2asn_clean.txt'
     rv_filtered_file = f'{context.out_dir_collectors}pfx2asn_filtered.txt'
 
-    general_merge(base_file, rv_file, rv_filtered_file, out_file)
+    general_merge(base_file, rv_file, rv_filtered_file, out_file, context.args.silent, context.args.workers)
     shutil.copy2(out_file, context.final_result_file)
 
 
-def general_merge(base_file, extra_file, extra_filtered_file, out_file):
-    pandarallel.initialize(progress_bar=True, verbose=0)
+def general_merge(base_file, extra_file, extra_filtered_file, out_file, silent=False, num_workers=0):
+    extra_kwargs = {'nb_workers': num_workers} if num_workers > 0 else {}
+    pandarallel.initialize(progress_bar=not silent, verbose=0, **extra_kwargs)
 
     print("Parse base file to numpy arrays")
     base_nets = []

--- a/module.nix
+++ b/module.nix
@@ -1,0 +1,85 @@
+flake: { config, pkgs, lib, ... }:
+
+with lib;
+
+let
+  inherit (flake.packages.${pkgs.stdenv.hostPlatform.system}) kartograf;
+  cfg = config.services.kartograf;
+  postScript = pkgs.writeScriptBin "post-script" /* bash */ ''
+    #!/${pkgs.bash}/bin/bash
+    timestamp=$(${pkgs.findutils}/bin/find out -mindepth 1 -maxdepth 1 -type d | ${pkgs.coreutils}/bin/cut -d/ -f2)
+    mv out/$timestamp/final_result.txt ${cfg.resultPath}/asmap-$timestamp.txt
+    echo "Copied result from /out/$timestamp/final_result.txt to ${cfg.resultPath}/asmap-$timestamp.txt"
+    rm -rf data out
+    echo "Cleaned up temporary directories."
+  '';
+in
+{
+  options.services.kartograf = {
+    enable = mkEnableOption "kartograf";
+    clean = mkEnableOption "cleaning up of temporarty artifacts after processing." // { default = true; };
+    silent = mkEnableOption "silencing output (suppresses pandarallel's progress_bar)." // { default = true; };
+    useIRR = mkEnableOption "using Internet Routing Registry (IRR) data" // { default = true; };
+    useRV = mkEnableOption "using RouteViews (RV) data" // { default = true; };
+    workers = mkOption {
+      type = types.int;
+      default = 0;
+      example = 4;
+      description = mdDoc "Number of workers to use for pandarallel (0 = use all available cores).";
+    };
+    schedule = mkOption {
+      type = types.str;
+      default = "*-*-01 00:00:00 UTC";
+      example = "monthly";
+      description = mdDoc "Systemd OnCalendar setting for kartograf.";
+    };
+    resultPath = mkOption {
+      type = types.path;
+      default = "/home/kartograf/";
+      example = "/scratch/results/kartograf/";
+      description = mdDoc "Directory for results.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    users = {
+      users.kartograf = {
+        isSystemUser = true;
+        group = "kartograf";
+        home = "/home/kartograf";
+        createHome = true;
+        homeMode = "755";
+      };
+      groups.kartograf = { };
+    };
+
+    systemd.timers.kartograf = {
+      wantedBy = [ "timers.target" ];
+      timerConfig = {
+        OnCalendar = cfg.schedule;
+        Unit = [ "kartograf.service" ];
+      };
+    };
+
+    systemd.services.kartograf = {
+      description = "kartograf";
+      after = [ "network-online.target" ];
+      serviceConfig = {
+        Environment = "PYTHONUNBUFFERED=1";
+        ExecStopPost = "${postScript}/bin/post-script";
+        ExecStart = ''${kartograf}/bin/kartograf map \
+          ${optionalString cfg.clean "--cleanup" } \
+          ${optionalString cfg.silent "--silent" } \
+          ${optionalString cfg.useIRR "--irr" } \
+          ${optionalString cfg.useRV "--routeviews" } \
+          ${optionalString (cfg.workers != 0) "--workers=${toString cfg.workers}" } \
+        '';
+        MemoryDenyWriteExecute = true;
+        WorkingDirectory = cfg.resultPath;
+        ReadWriteDirectories = cfg.resultPath;
+        User = "kartograf";
+        Group = "kartograf";
+      };
+    };
+  };
+}

--- a/module.nix
+++ b/module.nix
@@ -17,7 +17,7 @@ in
 {
   options.services.kartograf = {
     enable = mkEnableOption "kartograf";
-    clean = mkEnableOption "cleaning up of temporarty artifacts after processing." // { default = true; };
+    clean = mkEnableOption "cleaning up of temporary artifacts after processing." // { default = true; };
     silent = mkEnableOption "silencing output (suppresses pandarallel's progress_bar)." // { default = true; };
     useIRR = mkEnableOption "using Internet Routing Registry (IRR) data" // { default = true; };
     useRV = mkEnableOption "using RouteViews (RV) data" // { default = true; };

--- a/run
+++ b/run
@@ -52,9 +52,11 @@ if __name__ == "__main__":
     # services.
     # parser_map.add_argument("-f", "--announced_filter", action="store_true", default=False)
 
-    # TODO:
-    # Don't log progress and statistics
-    # parser_map.add_argument("-s", "--silent", action="store_true", default=False)
+    # Reduce log output (for now, affects only progress_bar in general_merge)
+    parser_map.add_argument("-s", "--silent", action="store_true", default=False)
+
+    # Number of workers to use for pandarallel
+    parser_map.add_argument("-p", "--workers", type=int, default=0)
 
     # TODO:
     # Include multiple ASNs that validate correctly for the same prefix.


### PR DESCRIPTION
Adds a NixOS module to facilitate scheduled runs. Removing any user action should increase the number of participants in community runs. 

Deployment via NixOS is as simple as:


```nix
services.kartograf = {
    enable = true;
    workers = 2;
};
```

The default schedule is monthly (`*-*-01 00:00:00 UTC`), but this is easily changed (e.g., `services.kartograf.schedule = weekly;`). By default,  IRR and RV data is used; this is can be changed via the `useIRR` and `useRV` settings.

I tried to avoid changes to kartograf code as much as possible, but some were necessary:
- Introduce a `-s`/`--silent` option, which is enabled in the module by default, to suppress output from `pandarallel` progress bar to avoid spamming the systemd journal with multiple BLOB entries per second.
- Introduce a `-p`/`--workers` option to set the number of threads for `pandarallel` to avoid hogging the CPU. (Since `pandarallel` is only used in the `merge` part, I don't see a problem with reproducibility when slowing down this part.)

The systemd job takes care of removing all data produced by kartograf except the final result to avoid filling up the file system (otherwise each run would contribute multiple GB of data, even when the `--clean` option is used). To avoid further changes to kartograf's code minimal, this task is handled via a systemd post-execution script.

P.S. I did not apply `nixpkgs-fmt` to the existing `flake.nix` file because I was not sure if the style was produced with a nix pretty printer I do not know. If it wasn't, let me know if it's ok to format the file.