### PR TITLE
Ci mock run

### DIFF
--- a/.github/workflows/build-nix-outputs.yml
+++ b/.github/workflows/build-nix-outputs.yml
@@ -1,7 +1,9 @@
-name: Build outputs
+name: Build Outputs
 
 on:
   push:
+    branches: [master]
+  pull_request:
     branches: [master]
 
 jobs:

--- a/.github/workflows/test-reproduction-run.yml
+++ b/.github/workflows/test-reproduction-run.yml
@@ -25,12 +25,5 @@ jobs:
         path: tests/data
 
     - name: Run with reproduction data
-      id: run_cmd
       run: |
-        output=$(nix develop --command ./run map -r tests/data/1742127147 -t 1742127147)
-        echo "output=$output" >> $GITHUB_OUTPUT
-
-    - name: Check output hash
-      if: ${{join(steps.run_cmd.outputs.*, '') contains '76835fb5d0002930ede434f396b38ab690e2b38193a516a5fb513ad2aa22e5af'
-      run: |
-        echo "Output matches the expected value"
+        nix develop --command ./run map -r tests/data/1742127147 -t 1742127147


### PR DESCRIPTION
Adding a mock, end-to-end run of the `map` process.

I would like to use actual downloaded RPKI data instead of a already validated data which would require a new flag just for this. However, having issues using actual RPKI data. I added two repositories: 
- a subset of the `rpki.arin.net` repo, with intermediate certs, CRL and MFT files.
- a full set from `rpki.sunoaki.net`. 

All these end up as `invalid` with the error `cannot find a local certificate issuer`. I think I have some gaps in understanding process here. 
- the `rpki-client` validation enforces the offline flag, so it should look for certs locally.
- The certs are in the repository path, and afaict `rpki-client` looks for the certs there. 
- the certificates are valid, with their `valid_until` date set far into the future.
- I'm not sure if you need the full recursive path -- with the (nested) ARIN repo, it looks like yes, which is why i added the whole path and chain of certs, but for sunoaki this should not be an issue. All end up as invalid.

Curious if you have an idea @fjahr if not I'll ask the rpki-client team. 
Thanks.
