### PR TITLE
Add podman Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,36 @@
+# Container description file for running kartograf
+FROM python:3.11
+ARG RPKI_VERSION=9.6
+
+# Download and install rpki-client from source
+RUN set -x && \
+  apt-get update && \
+  apt-get -y install libtls-dev rsync && \
+  wget "https://github.com/rpki-client/rpki-client-portable/releases/download/${RPKI_VERSION}/rpki-client-${RPKI_VERSION}.tar.gz" && \
+  tar xfz "rpki-client-${RPKI_VERSION}.tar.gz" && \
+  cd "rpki-client-${RPKI_VERSION}/"; \
+  ./configure \
+    --prefix=/usr \
+    --with-user=rpki-client \
+    --with-tal-dir=/etc/tals \
+    --with-base-dir=/var/cache/rpki-client \
+    --with-output-dir=/var/lib/rpki-client && \
+  make V=1 && \
+  addgroup --system --gid 900 rpki-client && \
+  adduser --system --home /var/lib/rpki-client --gid 900 rpki-client && \
+  make install && \
+  adduser --uid 1000 user && \
+  mkdir /data /out && \
+  chown user /data /out
+
+# Install kartograf's Python dependencies
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+USER user
+# Copy over Python module
+# We intentionally don't copy over `run` here, because the name "run" is created as a directory by podman.
+COPY kartograf kartograf
+
+# Define entry point
+ENTRYPOINT ["python3", "-m", "kartograf.cli"]

--- a/README.md
+++ b/README.md
@@ -33,6 +33,25 @@ experimental-features = nix-command flakes
 
 to enable flakes in your Nix config, then run `nix develop`.
 
+### Container
+
+The repository provies a `Containerfile` that builds a container with kartograf, the `rpki-client` binary, Python 3.11, and the Python packages required to run kartograf.
+
+If you have podman installed, you can run the utility with:
+
+```
+podman build --tag kartograf .
+podman run --rm -it kartograf map --help
+```
+
+To (optionally) copy out the compiled output, you can use:
+```
+podman run --name kartograf-run -it kartograf map -d
+podman cp kartograf-run:/out out   # (main output)
+podman cp kartograf-run:/data data # (to get intermediate data)
+podman rm kartograf-run
+```
+
 ### Linux/BSD/macOS
 
 #### rpki-client


### PR DESCRIPTION
This makes it possible to run kartograf in a container, with the correct versions. At this point, these are Python 3.11 and rpki-client 9.6.

Has been tested in podman on debian trixie. It is likely to work on docker as well, but i have not tested this.

Example: 
(edit: old example was no longer relevant- see README.md)
