### PR TITLE
cli: Make it possible to launch with `python -m kartograf.cli`

### DIFF
--- a/kartograf/cli.py
+++ b/kartograf/cli.py
@@ -112,3 +112,6 @@ def main(args=None):
     else:
         parser.print_help()
         sys.exit("Please provide a command.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Make  it possible to launch the cli with `python -m kartograf.cli`. This would avoid having to rename the `run` wrapper in #99.