### PR TITLE
bug: bring back reproduction run CI job

### DIFF
--- a/.github/workflows/test-reproduction-run.yml
+++ b/.github/workflows/test-reproduction-run.yml
@@ -25,5 +25,12 @@ jobs:
         path: tests/data
 
     - name: Run with reproduction data
+      id: run_cmd
       run: |
-        nix develop --command ./run map -r tests/data/1742127147 -t 1742127147
+        output=$(nix develop --command ./run map -r tests/data/1742127147 -t 1742127147 | tr '\n' ' ')
+        echo "output=$output" >> $GITHUB_OUTPUT
+
+    - name: Check output hash
+      if: contains(steps.run_cmd.outputs.output, '76835fb5d0002930ede434f396b38ab690e2b38193a516a5fb513ad2aa22e5af')
+      run: |
+        echo "Output matches the expected value"


### PR DESCRIPTION
the actions runner doesn't like output with linebreaks, so we replace all newlines with spaces in the output, and check for the presence of the hash in that string.