### PR TITLE
irr: Fix output cache key bug

### DIFF
--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -90,22 +90,22 @@ def parse_irr(context):
                     # There are duplicates and multiple entries for some
                     # prefixes in the IRR DBs, so we need to deal with them
                     # here.
-                    if output_cache.get(route):
-                        [old_origin, old_last_modified] = output_cache[route]
+                    if output_cache.get(parsed_route):
+                        [old_origin, old_last_modified] = output_cache[parsed_route]
 
                         # If there are two entries for the same prefix, we
                         # prefer the one with the newer last-modified date.
                         if int(last_modified) > int(old_last_modified):
-                            output_cache[route] = [origin, last_modified]
+                            output_cache[parsed_route] = [origin, last_modified]
 
                         # If the last-modified date is the same, we use the
                         # lower ASN as a deterministic tie-breaker.
                         if int(last_modified) == int(old_last_modified):
                             if int(origin[2:]) < int(old_origin[2:]):
-                                output_cache[route] = [origin, last_modified]
+                                output_cache[parsed_route] = [origin, last_modified]
 
                     else:
-                        output_cache[route] = [origin, last_modified]
+                        output_cache[parsed_route] = [origin, last_modified]
 
         print(f"Parsed {file.name}, found: {len(output_cache) - prev_count}")
 


### PR DESCRIPTION
This fixes a bug that was introduced in 00baaea51d083e07530639240f53ebeb97599762 which came in with https://github.com/asmap/kartograf/pull/91.

In this change the variable `route`, which holds the parsed version of the route, is renamed to `parsed_route`. The same variable is reused further below as a cache key. The variable name isn't changed in that place though. Normally this should have resulted in an unknown variable error, however, `route` wasn't a newly created variable where it was renamed. It was pre-existing and only reassigned so a (unparsed) `route` variable still existed in the same namespace. This pre-existing `route` variable was used as the cache key instead of the `parsed_route`. This meant the cache wasn't working as intended and the IRR parsing gave different results than before in very specific edge cases (duplicate prefixes that were not exact duplicates afaict).

I am mostly to blame for this issue because I initially created the code that re-used the `route` variable and didn't catch the bug in review of that commit later on.

This PR just fixes the issue. There will need to be some follow-up on the implications of dealing with this. The good thing is, this was only in master, not a release but people were using master in at least one run since this was introduced. So we need to check what kind of a diff this was causing in the created files and do we need to amend these? I think the diff might be very small but we need to investigate this.

We need to also improve our CI and test suite to catch such cases. I am also kind of surprised that our linter doesn't complain about re-assigned variables. We should add such a check to the linter CI in a follow-up. I also think that our progress in performance has made it possible that we can consider doing a full reproduction run of a full asmap if we can find a practical way to get the data into the CI job. Or maybe it's just something where we have a script that does this locally and we run this once we are about to release a new version or merge any critical changes.