### PR TITLE
fix: run python3 with line buffering on the `run` script

### DIFF
--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S python3 -u
 """
 This project allows to build a IP prefix to AS map using RPKI as the primary
 and IRR as the secondary data source. IRR data is only used if the RPKI data


### PR DESCRIPTION
Python uses full buffering when `stdout` is not a `tty` (eg when piping to `tee`), which prevents real-time output visibility. This PR adds the `-u` flag to enable line buffering, allowing output to be displayed immediately after each newline.

This ensures that commands like `./run map -w=1764864000 -irr -rv -s | tee run.txt` display output in real-time rather than buffering until completion.