### PR TITLE
Use trie in cov command

### DIFF
--- a/kartograf/coverage.py
+++ b/kartograf/coverage.py
@@ -1,7 +1,8 @@
 import ipaddress
 from kartograf.trie import IPTrie
+from kartograf.timed import timed
 
-
+@timed
 def coverage(map_file, ip_list_file, output_covered=None, output_uncovered=None):
     print("Running coverage check...\n")
 


### PR DESCRIPTION
rebased on #114 and #115

Uses the trie implementation from #115 in the `cov` command.

This changes the functionality in one important way: previously, the lookup returned the first network it found which matched the IP address. But if there was a more specific prefix (i.e. a more accurate home for it) later in the list, it would not reach it. The trie lookup always finds the longest matching prefix, which aligns with internet routing lookups.