### PR TITLE
upgrade nixpkgs to 25.11

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1732350895,
-        "narHash": "sha256-GcOQbOgmwlsRhpLGSwZJwLbo3pu9ochMETuRSS1xpz4=",
+        "lastModified": 1769598131,
+        "narHash": "sha256-e7VO/kGLgRMbWtpBqdWl0uFg8Y2XWFMdz0uUJvlML8o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c582677378f2d9ffcb01490af2f2c678dcb29d3",
+        "rev": "fa83fd837f3098e3e678e6cf017b2b36102c7211",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.11",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,8 @@
     # * A NixOS module
     devShells = forAllSystems (system: let
       pkgs = nixpkgsFor system;
-      pythonDevDeps = pkgs.python313.withPackages (ps: [
+      python = pkgs.python313;
+      pythonDevDeps = python.withPackages (ps: [
         ps.beautifulsoup4
         ps.pandas
         ps.pylint
@@ -40,7 +41,7 @@
       ]);
     in {
       default = pkgs.mkShell {
-        packages = [pythonDevDeps rpki-cli.packages.${system}.default];
+        packages = [python pythonDevDeps rpki-cli.packages.${system}.default];
       };
     });
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "An IP-to-AS mapping tool.";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
     # the rpki-client binary will be built from the flake at this URL.
     rpki-cli.url = "github:asmap/rpki-client-nix";
     rpki-cli.inputs.nixpkgs.follows = "nixpkgs";
@@ -30,7 +30,7 @@
     # * A NixOS module
     devShells = forAllSystems (system: let
       pkgs = nixpkgsFor system;
-      pythonDevDeps = pkgs.python311.withPackages (ps: [
+      pythonDevDeps = pkgs.python313.withPackages (ps: [
         ps.beautifulsoup4
         ps.pandas
         ps.pylint

--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, UTC
 from pathlib import Path
 import sys
 import time
@@ -92,9 +92,9 @@ class Context:
         '''
         if self.reproduce and self.epoch:
             # both reproduce and epoch args are set: this is a reproduction run
-            repro_epoch = datetime.utcfromtimestamp(int(self.args.epoch))
+            repro_epoch = datetime.fromtimestamp(int(self.args.epoch), UTC)
             self.epoch_dir = "r" + self.epoch
             self.epoch_datetime = repro_epoch
         else:
             self.epoch_dir = self.epoch
-            self.epoch_datetime = datetime.utcfromtimestamp(int(self.epoch))
+            self.epoch_datetime = datetime.fromtimestamp(int(self.epoch), UTC)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.11.1
+beautifulsoup4>=4.11.1
 pandas>=2.2.3
 requests>=2.31.0
 tqdm>=4.67.0


### PR DESCRIPTION
I saw a weird behavior when testing this, but it might be a local setup issue: it ended up building the python packages locally (which includes running all tests :/) which took forever. But these packages should be pulled from the binary cache (usually cache.nixos.org) not built locally.

I added an overlay to disable tests when fetching the packages, but since the package no longer matches the original, it forces a build locally too.

When testing this, run a `nix develop` and see what happens with the python packages.