### PR TITLE
upgrade Python version in Containerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # Container description file for running kartograf
-FROM python:3.11
+FROM python:3.13
 ARG RPKI_VERSION=9.7
 
 # Download and install rpki-client from source

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ to enable flakes in your Nix config, then run `nix develop`.
 
 ### Container
 
-The repository provies a `Containerfile` that builds a container with kartograf, the `rpki-client` binary, Python 3.11, and the Python packages required to run kartograf.
+The repository provies a `Containerfile` that builds a container with kartograf, the `rpki-client` binary, Python 3.13, and the Python packages required to run kartograf.
 
 If you have podman installed, you can run the utility with:
 


### PR DESCRIPTION
We upgraded the Python version in the Nix flake in cee72abbddd87ec5606b18974296b49f4ee476c7 and didn't upgrade the corresponding Containerfile version.

Tested pulling from dockerhub and running the container with podman as described in the READMe.

@laanwj you were right about 3.13 the first time :) 