### PR TITLE
followups from #116: handle divide by zero, remove timed

### DIFF
--- a/kartograf/coverage.py
+++ b/kartograf/coverage.py
@@ -1,13 +1,7 @@
 import ipaddress
 from kartograf.trie import IPTrie
-from kartograf.timed import timed
 
-@timed
 def coverage(map_file, ip_list_file, output_covered=None, output_uncovered=None):
-    print("Running coverage check...\n")
-
-    trie = IPTrie()
-    trie.from_map_file(map_file)
     addrs = []
     for line in ip_list_file:
         line = line.rstrip('\n')
@@ -21,6 +15,14 @@ def coverage(map_file, ip_list_file, output_covered=None, output_uncovered=None)
                   Invalid IPv4/IPv6 address provided: {line}.
                   Please remove and re-run.
                   """)
+    if len(addrs) == 0:
+        print("No IPs found in IP list file, cannot run coverage check.")
+        return
+
+    print("Running coverage check...")
+
+    trie = IPTrie()
+    trie.from_map_file(map_file)
 
     covered_pairs = []
     not_covered_ips = []

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -54,3 +54,12 @@ def test_not_covered_ips_output():
     with open(cov_output_file, 'r') as f:
         cov_output = f.readlines()
     assert "134.26.21.1\n" in cov_output
+
+def test_empty_ip_list(capsys):
+    map_file_path, _ = fixtures()
+    with open(map_file_path, 'r') as f:
+        map_items = f.readlines()
+    ip_items = [] # empty file result
+    coverage(map_items, ip_items)
+    captured = capsys.readouterr()
+    assert "No IPs found in IP list file" in captured.out


### PR DESCRIPTION
Return early if the IP list is empty.
Also, moves the trie creation after checking the IP list, since it is time-consuming.
Adds an empty IP list test.

I kept the "Running coverage check" print statement because, while the command is faster, it can still take around 10 seconds on my machine, which is a little long for having no feedback for the user. I removed the newline though. The statement is only printed after the IP list is checked and before the trie starts being built.  