### PR TITLE
Use epoch_datetime for RouteViews month selection

### DIFF
--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -85,15 +85,24 @@ def extract(file, context):
             write.write(formatted + '\n')
 
 
+def resolve_routeviews_urls(context):
+    """Resolve RouteViews download URLs for this epoch."""
+    epoch_dt = context.epoch_datetime
+    context.routeviews_v4_url = latest_link(PFX2AS_V4, epoch_dt)
+    context.routeviews_v6_url = latest_link(PFX2AS_V6, epoch_dt)
+    print(f"Resolved RouteViews URLs:\n  v4: {context.routeviews_v4_url}"
+          f"\n  v6: {context.routeviews_v6_url}")
+
+
 @timed
 def fetch_routeviews_pfx2as(context):
     path = Path(context.data_dir_collectors)
     v4_file_gz = path / "routeviews_pfx2asn_ip4.txt.gz"
     v6_file_gz = path / "routeviews_pfx2asn_ip6.txt.gz"
 
-    download(latest_link(PFX2AS_V4, context.epoch_datetime), v4_file_gz)
+    download(context.routeviews_v4_url, v4_file_gz)
     print(f"Downloaded {v4_file_gz.name}, file hash: {calculate_sha256(v4_file_gz)}")
-    download(latest_link(PFX2AS_V6, context.epoch_datetime), v6_file_gz)
+    download(context.routeviews_v6_url, v6_file_gz)
     print(f"Downloaded {v6_file_gz.name}, file hash: {calculate_sha256(v6_file_gz)}")
 
 

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 from pathlib import Path
 import gzip
 import shutil
@@ -16,9 +16,8 @@ PFX2AS_V4 = "https://publicdata.caida.org/datasets/routing/routeviews-prefix2as/
 PFX2AS_V6 = "https://publicdata.caida.org/datasets/routing/routeviews6-prefix2as/"
 
 
-def latest_link(base):
-    now = datetime.now()
-    ym = year_and_month(now)
+def latest_link(base, epoch_datetime):
+    ym = year_and_month(epoch_datetime)
     url = base + ym
 
     try:
@@ -28,7 +27,7 @@ def latest_link(base):
         print(f"The page at {url} couldn't be fetched. "
               f"Trying the previous month.")
 
-        last_month = now - timedelta(days=now.day)
+        last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
         ym = year_and_month(last_month)
         url = base + ym
 
@@ -92,9 +91,9 @@ def fetch_routeviews_pfx2as(context):
     v4_file_gz = path / "routeviews_pfx2asn_ip4.txt.gz"
     v6_file_gz = path / "routeviews_pfx2asn_ip6.txt.gz"
 
-    download(latest_link(PFX2AS_V4), v4_file_gz)
+    download(latest_link(PFX2AS_V4, context.epoch_datetime), v4_file_gz)
     print(f"Downloaded {v4_file_gz.name}, file hash: {calculate_sha256(v4_file_gz)}")
-    download(latest_link(PFX2AS_V6), v6_file_gz)
+    download(latest_link(PFX2AS_V6, context.epoch_datetime), v6_file_gz)
     print(f"Downloaded {v6_file_gz.name}, file hash: {calculate_sha256(v6_file_gz)}")
 
 

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -8,7 +8,7 @@ from bs4 import BeautifulSoup
 import requests
 
 from kartograf.timed import timed
-from kartograf.util import calculate_sha256
+from kartograf.util import calculate_sha256, download_with_retries
 
 # Routeviews Prefix to AS mappings Dataset for IPv4 and IPv6
 # https://www.caida.org/catalog/datasets/routeviews-prefix2as/
@@ -20,35 +20,36 @@ def latest_link(base, epoch_datetime):
     ym = year_and_month(epoch_datetime)
     url = base + ym
 
-    try:
-        response = requests.get(url, timeout=600)
-        response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        print(f"The page at {url} couldn't be fetched. "
-              f"Trying the previous month.")
+    response = download_with_retries(url)
+    if response:
+        latest = _pick_latest_pfx2as(response.text)
+        if latest:
+            return url + latest
 
-        last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
-        ym = year_and_month(last_month)
-        url = base + ym
+    print(f"No pfx2as.gz files at {url}. Trying the previous month.")
 
-        try:
-            response = requests.get(url, timeout=600)
-            response.raise_for_status()
-        except requests.exceptions.HTTPError:
-            print(f"The page at {url} couldn't be fetched. "
-                  f"Download of Routeviews pfx2as data failed.")
-            sys.exit()
+    last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
+    fallback_url = base + year_and_month(last_month)
 
-    soup = BeautifulSoup(response.text, 'html.parser')
+    response = download_with_retries(fallback_url)
+    if response:
+        latest = _pick_latest_pfx2as(response.text)
+        if latest:
+            return fallback_url + latest
 
+    print(f"The page at {fallback_url} also has no pfx2as.gz files. "
+          f"Download of Routeviews pfx2as data failed.")
+    sys.exit()
+
+
+def _pick_latest_pfx2as(html):
+    soup = BeautifulSoup(html, 'html.parser')
     links = [a["href"] for a in soup.find_all("a", href=True)]
     latest = ""
-
     for link in links:
         if link.endswith(".pfx2as.gz"):
             latest = link
-
-    return url + latest
+    return latest
 
 
 def year_and_month(now):

--- a/kartograf/irr/fetch.py
+++ b/kartograf/irr/fetch.py
@@ -1,12 +1,10 @@
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import gzip
 import shutil
-import time
 from pathlib import Path
-import requests
 
 from kartograf.timed import timed
-from kartograf.util import calculate_sha256
+from kartograf.util import calculate_sha256, download_with_retries
 
 IRR_FILE_ADDRESSES = [
     # AFRINIC
@@ -27,30 +25,18 @@ def download_single_irr_file(url, context):
     """Download a single IRR file with retry logic"""
     file_name = url.rsplit('/', maxsplit=1)[-1]
     local_file_path = Path(context.data_dir_irr) / file_name
-    attempt = 0
-    max_retries = 5
-    retry_delay = 2
 
     print(f"Starting download: {file_name}")
-    while attempt < max_retries:
-        try:
-            response = requests.get(url, stream=True, timeout=(15, 120))
-            response.raise_for_status()
-            with open(local_file_path, 'wb') as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
-            file_hash = calculate_sha256(local_file_path)
-            print(f"Downloaded {file_name}, file hash: {file_hash}")
-            return {'status': 'success'}
-        except (requests.RequestException, ConnectionError) as e:
-            print(f"Connection issue while downloading {file_name}: {e}. Retrying... (Attempt {attempt + 1}/{max_retries})")
-            attempt += 1
-            if attempt < max_retries:
-                time.sleep(retry_delay)
-
-    error_msg = f"Error: Failed to download {file_name} after {max_retries} attempts."
-    print(f"✗ {error_msg}")
-    return {'status': 'failed'}
+    try:
+        download_with_retries(url, timeout=(15, 120), max_retries=5,
+                              retry_delay=2, stream=True,
+                              dest_path=local_file_path)
+        file_hash = calculate_sha256(local_file_path)
+        print(f"Downloaded {file_name}, file hash: {file_hash}")
+        return {'status': 'success'}
+    except Exception as e:
+        print(f"✗ Error: Failed to download {file_name}: {e}")
+        return {'status': 'failed'}
 
 
 @timed

--- a/kartograf/kartograf.py
+++ b/kartograf/kartograf.py
@@ -7,7 +7,11 @@ from kartograf.cleanup import cleanup_out_files
 
 from kartograf.context import Context
 from kartograf.coverage import coverage
-from kartograf.collectors.routeviews import extract_routeviews_pfx2as, fetch_routeviews_pfx2as
+from kartograf.collectors.routeviews import (
+    extract_routeviews_pfx2as,
+    fetch_routeviews_pfx2as,
+    resolve_routeviews_urls,
+)
 from kartograf.collectors.parse import parse_routeviews_pfx2as
 from kartograf.irr.fetch import extract_irr, fetch_irr
 from kartograf.irr.parse import parse_irr
@@ -56,6 +60,12 @@ class Kartograf:
             repro_path = context.args.reproduce
             print(f"This is a reproduction run based on the data in "
                   f"{repro_path}")
+
+        # Resolve RouteViews URLs early so all coordinated-launch
+        # participants see the same CAIDA directory state.
+        if not context.reproduce and context.args.routeviews:
+            print_section_header("Resolving RouteViews URLs")
+            resolve_routeviews_urls(context)
 
         # Fetch everthing that we need to fetch first
         if not context.reproduce:

--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -6,7 +6,38 @@ import re
 import subprocess
 import time
 
+import requests
+
 RPKI_VERSION = 9.7
+
+
+def download_with_retries(url, timeout=600, max_retries=3, retry_delay=10,
+                          stream=False, dest_path=None):
+    """Download a URL with retries on request failures.
+
+    Returns the Response on success.  404 is not retried and returns None.
+    Other request failures are retried up to max_retries times.
+    If dest_path is provided, the response body is streamed to that file.
+    """
+    for attempt in range(1, max_retries + 1):
+        try:
+            response = requests.get(url, stream=stream, timeout=timeout)
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            if dest_path:
+                with open(dest_path, 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        f.write(chunk)
+            return response
+        except requests.exceptions.RequestException as e:
+            if attempt < max_retries:
+                print(f"Request to {url} failed ({e}), "
+                      f"retrying in {retry_delay}s "
+                      f"(attempt {attempt}/{max_retries})...")
+                time.sleep(retry_delay)
+            else:
+                raise
 
 
 def calculate_sha256(file_path):


### PR DESCRIPTION
Resolve RouteViews URLs at run start (before RPKI/IRR) so all coordinated-launch participants see the same CAIDA directory state. Also uses epoch_datetime for month selection and falls back on empty directories.

Fixes #128, observed in bitcoin-core/asmap-data#46.