### PR TITLE
Filter RouteViews pfx2as files by epoch timestamp

### DIFF
--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -1,9 +1,9 @@
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from pathlib import Path
 import gzip
-import re
 import shutil
 import sys
+import tempfile
 import time
 
 from bs4 import BeautifulSoup
@@ -21,48 +21,73 @@ RETRY_ATTEMPTS = 3
 RETRY_DELAY = 10
 
 
-def _parse_upload_time(text):
-    """Parse an upload timestamp from the CAIDA Apache directory listing.
+def _get_gzip_mtime(url):
+    """Download a gzip file to a temp path and return its header mtime."""
+    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".gz")
+    try:
+        response = requests.get(url, stream=True, timeout=300)
+        response.raise_for_status()
+        for chunk in response.iter_content(chunk_size=8192):
+            tmp.write(chunk)
+        tmp.close()
+        with gzip.open(tmp.name, 'rb') as f:
+            f.read(1)  # header is parsed on first read
+            return f.mtime
+    finally:
+        Path(tmp.name).unlink(missing_ok=True)
 
-    The listing shows timestamps in US/Pacific time as YYYY-MM-DD HH:MM.
-    Returns a UTC datetime, or None if the timestamp cannot be parsed.
+
+def _pick_pfx2as_files(html):
+    """Return all pfx2as.gz filenames from the directory listing, in order."""
+    soup = BeautifulSoup(html, 'html.parser')
+    files = []
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if href.endswith(".pfx2as.gz"):
+            files.append(href)
+    return files
+
+
+def latest_link(base, epoch_datetime):
+    """Find the latest pfx2as file that existed at or before the epoch.
+
+    Downloads the latest file and checks its gzip header timestamp.
+    If it was created after the epoch, falls back to the previous file.
     """
-    m = re.search(r'(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})', text)
-    if not m:
-        return None
-    # CAIDA is in San Diego (US/Pacific). Rather than pulling in pytz/
-    # zoneinfo just for this, we apply the worst-case UTC-7 (PDT) offset
-    # so the filter is conservative: a file uploaded at 09:13 Pacific is
-    # treated as 16:13 UTC regardless of DST.
-    PACIFIC_OFFSET = timedelta(hours=-7)
-    pacific = timezone(PACIFIC_OFFSET)
-    local_dt = datetime.strptime(m.group(1), '%Y-%m-%d %H:%M').replace(
-        tzinfo=pacific)
-    return local_dt.astimezone(timezone.utc)
+    epoch_ts = int(epoch_datetime.timestamp())
+    ym = year_and_month(epoch_datetime)
+    url = base + ym
+
+    result = _pick_valid_file(url, epoch_ts)
+    if result:
+        return result
+
+    print(f"No valid pfx2as.gz files at {url}. Trying the previous month.")
+
+    last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
+    fallback_url = base + year_and_month(last_month)
+
+    result = _pick_valid_file(fallback_url, epoch_ts)
+    if result:
+        return result
+
+    print(f"The page at {fallback_url} also has no pfx2as.gz files. "
+          f"Download of Routeviews pfx2as data failed.")
+    sys.exit()
 
 
-def _try_fetch_latest(base_url, epoch_datetime):
-    """Fetch directory listing and return the latest pfx2as file.
+def _pick_valid_file(base_url, epoch_ts):
+    """Pick the latest pfx2as file whose gzip mtime is <= epoch_ts.
 
-    Returns the full URL on success, None if the page exists but contains
-    no pfx2as.gz files.  Raises on request failures so the caller can retry.
-    Only considers files whose upload time is at or before epoch_datetime.
+    Fetches the directory listing, then checks files from newest to oldest.
     """
-    response = requests.get(base_url, timeout=600)
-    if response.status_code == 404:
-        return None
-    response.raise_for_status()
-    latest = _pick_latest_pfx2as(response.text, epoch_datetime)
-    if latest:
-        return base_url + latest
-    return None
-
-
-def _fetch_with_retry(base_url, epoch_datetime):
-    """Call _try_fetch_latest with retries for request failures only."""
     for attempt in range(1, RETRY_ATTEMPTS + 1):
         try:
-            return _try_fetch_latest(base_url, epoch_datetime)
+            response = requests.get(base_url, timeout=600)
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            break
         except requests.exceptions.RequestException as e:
             if attempt < RETRY_ATTEMPTS:
                 print(f"Request to {base_url} failed ({e}), "
@@ -72,50 +97,20 @@ def _fetch_with_retry(base_url, epoch_datetime):
             else:
                 raise
 
+    files = _pick_pfx2as_files(response.text)
+    if not files:
+        return None
 
-def latest_link(base, epoch_datetime):
-    ym = year_and_month(epoch_datetime)
-    url = base + ym
-
-    result = _fetch_with_retry(url, epoch_datetime)
-    if result:
-        return result
-
-    print(f"No pfx2as.gz files at {url}. Trying the previous month.")
-
-    last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
-    fallback_url = base + year_and_month(last_month)
-
-    result = _fetch_with_retry(fallback_url, epoch_datetime)
-    if result:
-        return result
-
-    print(f"The page at {fallback_url} also has no pfx2as.gz files. "
-          f"Download of Routeviews pfx2as data failed.")
-    sys.exit()
-
-
-def _pick_latest_pfx2as(html, epoch_datetime):
-    """Pick the latest pfx2as file uploaded at or before epoch_datetime.
-
-    Parses the upload timestamps shown in the CAIDA Apache directory
-    listing rather than the collection timestamps embedded in filenames.
-    """
-    epoch_utc = epoch_datetime.replace(tzinfo=timezone.utc)
-    soup = BeautifulSoup(html, 'html.parser')
-    latest = ""
-    for a in soup.find_all("a", href=True):
-        href = a["href"]
-        if not href.endswith(".pfx2as.gz"):
+    # Check from newest to oldest
+    for filename in reversed(files):
+        file_url = base_url + filename
+        mtime = _get_gzip_mtime(file_url)
+        if mtime and mtime > epoch_ts:
+            print(f"Skipping {filename} (gzip mtime {mtime} > epoch {epoch_ts})")
             continue
-        # The upload timestamp appears in the text node after the <a> tag
-        sibling_text = a.next_sibling
-        if sibling_text:
-            upload_time = _parse_upload_time(str(sibling_text))
-            if upload_time and upload_time > epoch_utc:
-                continue
-        latest = href
-    return latest
+        return file_url
+
+    return None
 
 
 def year_and_month(now):

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -3,16 +3,12 @@ from pathlib import Path
 import gzip
 import shutil
 import sys
-import time
 
 from bs4 import BeautifulSoup
 import requests
 
 from kartograf.timed import timed
 from kartograf.util import calculate_sha256
-
-RETRY_ATTEMPTS = 3
-RETRY_DELAY = 120  # seconds
 
 # Routeviews Prefix to AS mappings Dataset for IPv4 and IPv6
 # https://www.caida.org/catalog/datasets/routeviews-prefix2as/
@@ -37,17 +33,11 @@ def latest_link(base, epoch_datetime):
     ym = year_and_month(epoch_datetime)
     url = base + ym
 
-    for attempt in range(RETRY_ATTEMPTS):
-        result = _try_fetch_latest(url)
-        if result:
-            return result
-        if attempt < RETRY_ATTEMPTS - 1:
-            print(f"No pfx2as.gz files at {url}, "
-                  f"retrying in {RETRY_DELAY}s ({attempt + 1}/{RETRY_ATTEMPTS})")
-            time.sleep(RETRY_DELAY)
+    result = _try_fetch_latest(url)
+    if result:
+        return result
 
-    print(f"No pfx2as.gz files at {url} after {RETRY_ATTEMPTS} attempts. "
-          f"Trying the previous month.")
+    print(f"No pfx2as.gz files at {url}. Trying the previous month.")
 
     last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
     fallback_url = base + year_and_month(last_month)

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -91,16 +91,25 @@ def extract(file, context):
             write.write(formatted + '\n')
 
 
+def resolve_routeviews_urls(context):
+    """Resolve RouteViews download URLs early so all participants in a
+    coordinated launch see the same CAIDA directory state."""
+    epoch_dt = context.epoch_datetime
+    context.routeviews_v4_url = latest_link(PFX2AS_V4, epoch_dt)
+    context.routeviews_v6_url = latest_link(PFX2AS_V6, epoch_dt)
+    print(f"Resolved RouteViews URLs:\n  v4: {context.routeviews_v4_url}"
+          f"\n  v6: {context.routeviews_v6_url}")
+
+
 @timed
 def fetch_routeviews_pfx2as(context):
     path = Path(context.data_dir_collectors)
     v4_file_gz = path / "routeviews_pfx2asn_ip4.txt.gz"
     v6_file_gz = path / "routeviews_pfx2asn_ip6.txt.gz"
 
-    epoch_dt = context.epoch_datetime
-    download(latest_link(PFX2AS_V4, epoch_dt), v4_file_gz)
+    download(context.routeviews_v4_url, v4_file_gz)
     print(f"Downloaded {v4_file_gz.name}, file hash: {calculate_sha256(v4_file_gz)}")
-    download(latest_link(PFX2AS_V6, epoch_dt), v6_file_gz)
+    download(context.routeviews_v6_url, v6_file_gz)
     print(f"Downloaded {v6_file_gz.name}, file hash: {calculate_sha256(v6_file_gz)}")
 
 

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -16,19 +16,21 @@ PFX2AS_V4 = "https://publicdata.caida.org/datasets/routing/routeviews-prefix2as/
 PFX2AS_V6 = "https://publicdata.caida.org/datasets/routing/routeviews6-prefix2as/"
 
 
-def latest_link(base):
-    now = datetime.now()
-    ym = year_and_month(now)
+def latest_link(base, epoch_datetime):
+    ym = year_and_month(epoch_datetime)
     url = base + ym
 
     try:
         response = requests.get(url, timeout=600)
         response.raise_for_status()
-    except requests.exceptions.HTTPError:
-        print(f"The page at {url} couldn't be fetched. "
-              f"Trying the previous month.")
+        latest = _pick_latest_pfx2as(response.text)
+        if not latest:
+            raise ValueError("no pfx2as.gz files in directory")
+    except (requests.exceptions.HTTPError, ValueError) as e:
+        print(f"The page at {url} couldn't be fetched or has no pfx2as.gz files "
+              f"({e}). Trying the previous month.")
 
-        last_month = now - timedelta(days=now.day)
+        last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
         ym = year_and_month(last_month)
         url = base + ym
 
@@ -40,16 +42,19 @@ def latest_link(base):
                   f"Download of Routeviews pfx2as data failed.")
             sys.exit()
 
-    soup = BeautifulSoup(response.text, 'html.parser')
+        latest = _pick_latest_pfx2as(response.text)
 
+    return url + latest
+
+
+def _pick_latest_pfx2as(html):
+    soup = BeautifulSoup(html, 'html.parser')
     links = [a["href"] for a in soup.find_all("a", href=True)]
     latest = ""
-
     for link in links:
         if link.endswith(".pfx2as.gz"):
             latest = link
-
-    return url + latest
+    return latest
 
 
 def year_and_month(now):
@@ -92,9 +97,10 @@ def fetch_routeviews_pfx2as(context):
     v4_file_gz = path / "routeviews_pfx2asn_ip4.txt.gz"
     v6_file_gz = path / "routeviews_pfx2asn_ip6.txt.gz"
 
-    download(latest_link(PFX2AS_V4), v4_file_gz)
+    epoch_dt = context.epoch_datetime
+    download(latest_link(PFX2AS_V4, epoch_dt), v4_file_gz)
     print(f"Downloaded {v4_file_gz.name}, file hash: {calculate_sha256(v4_file_gz)}")
-    download(latest_link(PFX2AS_V6), v6_file_gz)
+    download(latest_link(PFX2AS_V6, epoch_dt), v6_file_gz)
     print(f"Downloaded {v6_file_gz.name}, file hash: {calculate_sha256(v6_file_gz)}")
 
 

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -21,17 +21,24 @@ RETRY_ATTEMPTS = 3
 RETRY_DELAY = 10
 
 
-def _parse_pfx2as_timestamp(filename):
-    """Extract a UTC datetime from a pfx2as filename.
+def _parse_upload_time(text):
+    """Parse an upload timestamp from the CAIDA Apache directory listing.
 
-    Filenames follow the pattern: routeviews-rv2-YYYYMMDD-HHMM.pfx2as.gz
-    Returns None if the timestamp cannot be parsed.
+    The listing shows timestamps in US/Pacific time as YYYY-MM-DD HH:MM.
+    Returns a UTC datetime, or None if the timestamp cannot be parsed.
     """
-    m = re.search(r'(\d{8})-(\d{4})\.pfx2as\.gz$', filename)
+    m = re.search(r'(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2})', text)
     if not m:
         return None
-    return datetime.strptime(m.group(1) + m.group(2), '%Y%m%d%H%M').replace(
-        tzinfo=timezone.utc)
+    # CAIDA is in San Diego (US/Pacific). Rather than pulling in pytz/
+    # zoneinfo just for this, we apply the worst-case UTC-7 (PDT) offset
+    # so the filter is conservative: a file uploaded at 09:13 Pacific is
+    # treated as 16:13 UTC regardless of DST.
+    PACIFIC_OFFSET = timedelta(hours=-7)
+    pacific = timezone(PACIFIC_OFFSET)
+    local_dt = datetime.strptime(m.group(1), '%Y-%m-%d %H:%M').replace(
+        tzinfo=pacific)
+    return local_dt.astimezone(timezone.utc)
 
 
 def _try_fetch_latest(base_url, epoch_datetime):
@@ -39,7 +46,7 @@ def _try_fetch_latest(base_url, epoch_datetime):
 
     Returns the full URL on success, None if the page exists but contains
     no pfx2as.gz files.  Raises on request failures so the caller can retry.
-    Only considers files with timestamps at or before epoch_datetime.
+    Only considers files whose upload time is at or before epoch_datetime.
     """
     response = requests.get(base_url, timeout=600)
     if response.status_code == 404:
@@ -89,18 +96,25 @@ def latest_link(base, epoch_datetime):
 
 
 def _pick_latest_pfx2as(html, epoch_datetime):
-    """Pick the latest pfx2as file that existed by the epoch time."""
+    """Pick the latest pfx2as file uploaded at or before epoch_datetime.
+
+    Parses the upload timestamps shown in the CAIDA Apache directory
+    listing rather than the collection timestamps embedded in filenames.
+    """
     epoch_utc = epoch_datetime.replace(tzinfo=timezone.utc)
     soup = BeautifulSoup(html, 'html.parser')
-    links = [a["href"] for a in soup.find_all("a", href=True)]
     latest = ""
-    for link in links:
-        if not link.endswith(".pfx2as.gz"):
+    for a in soup.find_all("a", href=True):
+        href = a["href"]
+        if not href.endswith(".pfx2as.gz"):
             continue
-        ts = _parse_pfx2as_timestamp(link)
-        if ts and ts > epoch_utc:
-            continue
-        latest = link
+        # The upload timestamp appears in the text node after the <a> tag
+        sibling_text = a.next_sibling
+        if sibling_text:
+            upload_time = _parse_upload_time(str(sibling_text))
+            if upload_time and upload_time > epoch_utc:
+                continue
+        latest = href
     return latest
 
 

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -17,7 +17,7 @@ PFX2AS_V4 = "https://publicdata.caida.org/datasets/routing/routeviews-prefix2as/
 PFX2AS_V6 = "https://publicdata.caida.org/datasets/routing/routeviews6-prefix2as/"
 
 RETRY_ATTEMPTS = 3
-RETRY_DELAY = 30
+RETRY_DELAY = 10
 
 
 def _try_fetch_latest(base_url):
@@ -27,6 +27,8 @@ def _try_fetch_latest(base_url):
     no pfx2as.gz files.  Raises on request failures so the caller can retry.
     """
     response = requests.get(base_url, timeout=600)
+    if response.status_code == 404:
+        return None
     response.raise_for_status()
     latest = _pick_latest_pfx2as(response.text)
     if latest:

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -1,6 +1,7 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 import gzip
+import re
 import shutil
 import sys
 import time
@@ -20,27 +21,41 @@ RETRY_ATTEMPTS = 3
 RETRY_DELAY = 10
 
 
-def _try_fetch_latest(base_url):
+def _parse_pfx2as_timestamp(filename):
+    """Extract a UTC datetime from a pfx2as filename.
+
+    Filenames follow the pattern: routeviews-rv2-YYYYMMDD-HHMM.pfx2as.gz
+    Returns None if the timestamp cannot be parsed.
+    """
+    m = re.search(r'(\d{8})-(\d{4})\.pfx2as\.gz$', filename)
+    if not m:
+        return None
+    return datetime.strptime(m.group(1) + m.group(2), '%Y%m%d%H%M').replace(
+        tzinfo=timezone.utc)
+
+
+def _try_fetch_latest(base_url, epoch_datetime):
     """Fetch directory listing and return the latest pfx2as file.
 
     Returns the full URL on success, None if the page exists but contains
     no pfx2as.gz files.  Raises on request failures so the caller can retry.
+    Only considers files with timestamps at or before epoch_datetime.
     """
     response = requests.get(base_url, timeout=600)
     if response.status_code == 404:
         return None
     response.raise_for_status()
-    latest = _pick_latest_pfx2as(response.text)
+    latest = _pick_latest_pfx2as(response.text, epoch_datetime)
     if latest:
         return base_url + latest
     return None
 
 
-def _fetch_with_retry(base_url):
+def _fetch_with_retry(base_url, epoch_datetime):
     """Call _try_fetch_latest with retries for request failures only."""
     for attempt in range(1, RETRY_ATTEMPTS + 1):
         try:
-            return _try_fetch_latest(base_url)
+            return _try_fetch_latest(base_url, epoch_datetime)
         except requests.exceptions.RequestException as e:
             if attempt < RETRY_ATTEMPTS:
                 print(f"Request to {base_url} failed ({e}), "
@@ -55,7 +70,7 @@ def latest_link(base, epoch_datetime):
     ym = year_and_month(epoch_datetime)
     url = base + ym
 
-    result = _fetch_with_retry(url)
+    result = _fetch_with_retry(url, epoch_datetime)
     if result:
         return result
 
@@ -64,7 +79,7 @@ def latest_link(base, epoch_datetime):
     last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
     fallback_url = base + year_and_month(last_month)
 
-    result = _fetch_with_retry(fallback_url)
+    result = _fetch_with_retry(fallback_url, epoch_datetime)
     if result:
         return result
 
@@ -73,13 +88,19 @@ def latest_link(base, epoch_datetime):
     sys.exit()
 
 
-def _pick_latest_pfx2as(html):
+def _pick_latest_pfx2as(html, epoch_datetime):
+    """Pick the latest pfx2as file that existed by the epoch time."""
+    epoch_utc = epoch_datetime.replace(tzinfo=timezone.utc)
     soup = BeautifulSoup(html, 'html.parser')
     links = [a["href"] for a in soup.find_all("a", href=True)]
     latest = ""
     for link in links:
-        if link.endswith(".pfx2as.gz"):
-            latest = link
+        if not link.endswith(".pfx2as.gz"):
+            continue
+        ts = _parse_pfx2as_timestamp(link)
+        if ts and ts > epoch_utc:
+            continue
+        latest = link
     return latest
 
 

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import gzip
 import shutil
 import sys
+import time
 
 from bs4 import BeautifulSoup
 import requests
@@ -15,25 +16,44 @@ from kartograf.util import calculate_sha256
 PFX2AS_V4 = "https://publicdata.caida.org/datasets/routing/routeviews-prefix2as/"
 PFX2AS_V6 = "https://publicdata.caida.org/datasets/routing/routeviews6-prefix2as/"
 
+RETRY_ATTEMPTS = 3
+RETRY_DELAY = 30
+
 
 def _try_fetch_latest(base_url):
-    """Fetch directory listing and return the latest pfx2as file, or None."""
-    try:
-        response = requests.get(base_url, timeout=600)
-        response.raise_for_status()
-        latest = _pick_latest_pfx2as(response.text)
-        if latest:
-            return base_url + latest
-    except requests.exceptions.HTTPError:
-        pass
+    """Fetch directory listing and return the latest pfx2as file.
+
+    Returns the full URL on success, None if the page exists but contains
+    no pfx2as.gz files.  Raises on request failures so the caller can retry.
+    """
+    response = requests.get(base_url, timeout=600)
+    response.raise_for_status()
+    latest = _pick_latest_pfx2as(response.text)
+    if latest:
+        return base_url + latest
     return None
+
+
+def _fetch_with_retry(base_url):
+    """Call _try_fetch_latest with retries for request failures only."""
+    for attempt in range(1, RETRY_ATTEMPTS + 1):
+        try:
+            return _try_fetch_latest(base_url)
+        except requests.exceptions.RequestException as e:
+            if attempt < RETRY_ATTEMPTS:
+                print(f"Request to {base_url} failed ({e}), "
+                      f"retrying in {RETRY_DELAY}s "
+                      f"(attempt {attempt}/{RETRY_ATTEMPTS})...")
+                time.sleep(RETRY_DELAY)
+            else:
+                raise
 
 
 def latest_link(base, epoch_datetime):
     ym = year_and_month(epoch_datetime)
     url = base + ym
 
-    result = _try_fetch_latest(url)
+    result = _fetch_with_retry(url)
     if result:
         return result
 
@@ -42,7 +62,7 @@ def latest_link(base, epoch_datetime):
     last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
     fallback_url = base + year_and_month(last_month)
 
-    result = _try_fetch_latest(fallback_url)
+    result = _fetch_with_retry(fallback_url)
     if result:
         return result
 

--- a/kartograf/collectors/routeviews.py
+++ b/kartograf/collectors/routeviews.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import gzip
 import shutil
 import sys
+import time
 
 from bs4 import BeautifulSoup
 import requests
@@ -10,41 +11,54 @@ import requests
 from kartograf.timed import timed
 from kartograf.util import calculate_sha256
 
+RETRY_ATTEMPTS = 3
+RETRY_DELAY = 120  # seconds
+
 # Routeviews Prefix to AS mappings Dataset for IPv4 and IPv6
 # https://www.caida.org/catalog/datasets/routeviews-prefix2as/
 PFX2AS_V4 = "https://publicdata.caida.org/datasets/routing/routeviews-prefix2as/"
 PFX2AS_V6 = "https://publicdata.caida.org/datasets/routing/routeviews6-prefix2as/"
 
 
+def _try_fetch_latest(base_url):
+    """Fetch directory listing and return the latest pfx2as file, or None."""
+    try:
+        response = requests.get(base_url, timeout=600)
+        response.raise_for_status()
+        latest = _pick_latest_pfx2as(response.text)
+        if latest:
+            return base_url + latest
+    except requests.exceptions.HTTPError:
+        pass
+    return None
+
+
 def latest_link(base, epoch_datetime):
     ym = year_and_month(epoch_datetime)
     url = base + ym
 
-    try:
-        response = requests.get(url, timeout=600)
-        response.raise_for_status()
-        latest = _pick_latest_pfx2as(response.text)
-        if not latest:
-            raise ValueError("no pfx2as.gz files in directory")
-    except (requests.exceptions.HTTPError, ValueError) as e:
-        print(f"The page at {url} couldn't be fetched or has no pfx2as.gz files "
-              f"({e}). Trying the previous month.")
+    for attempt in range(RETRY_ATTEMPTS):
+        result = _try_fetch_latest(url)
+        if result:
+            return result
+        if attempt < RETRY_ATTEMPTS - 1:
+            print(f"No pfx2as.gz files at {url}, "
+                  f"retrying in {RETRY_DELAY}s ({attempt + 1}/{RETRY_ATTEMPTS})")
+            time.sleep(RETRY_DELAY)
 
-        last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
-        ym = year_and_month(last_month)
-        url = base + ym
+    print(f"No pfx2as.gz files at {url} after {RETRY_ATTEMPTS} attempts. "
+          f"Trying the previous month.")
 
-        try:
-            response = requests.get(url, timeout=600)
-            response.raise_for_status()
-        except requests.exceptions.HTTPError:
-            print(f"The page at {url} couldn't be fetched. "
-                  f"Download of Routeviews pfx2as data failed.")
-            sys.exit()
+    last_month = epoch_datetime - timedelta(days=epoch_datetime.day)
+    fallback_url = base + year_and_month(last_month)
 
-        latest = _pick_latest_pfx2as(response.text)
+    result = _try_fetch_latest(fallback_url)
+    if result:
+        return result
 
-    return url + latest
+    print(f"The page at {fallback_url} also has no pfx2as.gz files. "
+          f"Download of Routeviews pfx2as data failed.")
+    sys.exit()
 
 
 def _pick_latest_pfx2as(html):

--- a/kartograf/kartograf.py
+++ b/kartograf/kartograf.py
@@ -7,7 +7,7 @@ from kartograf.cleanup import cleanup_out_files
 
 from kartograf.context import Context
 from kartograf.coverage import coverage
-from kartograf.collectors.routeviews import extract_routeviews_pfx2as, fetch_routeviews_pfx2as
+from kartograf.collectors.routeviews import extract_routeviews_pfx2as, fetch_routeviews_pfx2as, resolve_routeviews_urls
 from kartograf.collectors.parse import parse_routeviews_pfx2as
 from kartograf.irr.fetch import extract_irr, fetch_irr
 from kartograf.irr.parse import parse_irr
@@ -56,6 +56,11 @@ class Kartograf:
             repro_path = context.args.reproduce
             print(f"This is a reproduction run based on the data in "
                   f"{repro_path}")
+
+        # Resolve RouteViews URLs early so all coordinated-launch
+        # participants see the same CAIDA directory state.
+        if not context.reproduce and context.args.routeviews:
+            resolve_routeviews_urls(context)
 
         # Fetch everthing that we need to fetch first
         if not context.reproduce:


### PR DESCRIPTION
Follow-up to #129. As suggested by @achow101 in #128, `_pick_latest_pfx2as` now parses the timestamp from pfx2as filenames (e.g. `routeviews-rv2-20260402-1600.pfx2as.gz`) and skips any file with a timestamp after the epoch. This ensures coordinated-launch participants select the same file even when new files appear on CAIDA mid-run.