### PR TITLE
cli/util: add explicit rpki backend compatibility guardrails

### DIFF
--- a/kartograf/cli.py
+++ b/kartograf/cli.py
@@ -6,6 +6,7 @@ import sys
 import time
 import kartograf
 from kartograf.kartograf import Kartograf
+from kartograf.util import KartografConfigurationError
 
 
 def create_parser():
@@ -48,6 +49,18 @@ def create_parser():
     parser_map.add_argument("-s", "--stable-repos", action="store_true", default=False,
                           help="Use only known stable RPKI repositories")
 
+    # Select the RPKI validation backend. We default to legacy to preserve deterministic behavior and backwards compatibility.
+    parser_map.add_argument(
+        "--rpki-backend",
+        choices=["legacy", "threaded"],
+        default="legacy",
+        help=(
+            "RPKI validation backend to use. "
+            "Use 'legacy' for current deterministic behavior. "
+            "'threaded' is experimental and requires rpki-client >= 9.6."
+        ),
+    )
+
     # TODO:
     # Filter RPKI and IRR data by checking against RIPE RIS and Routeviews data
     # and removing all entries that have not been seen announced to those
@@ -85,8 +98,18 @@ def create_parser():
     return parser
 
 def is_root():
-    # Get current the Effective UID. On Unix systems the root user EUID is 0.
-    return os.geteuid() == 0
+    # On Windows, check Administrator privileges through the Win32 API.
+    if os.name == "nt":
+        try:
+            import ctypes
+
+            return bool(ctypes.windll.shell32.IsUserAnAdmin())
+        except Exception:
+            return False
+
+    # On Unix systems the root user EUID is 0.
+    geteuid = getattr(os, "geteuid", None)
+    return geteuid() == 0 if geteuid else False
 
 def main(args=None):
     parser = create_parser()
@@ -104,11 +127,20 @@ def main(args=None):
         if args.wait and args.reproduce:
             parser.error("--reproduce is not compatible with --wait.")
 
-        if args.wait and (int(args.wait) < time.time()):
-            parser.error(f"Cannot wait for a timestamp in the past ({args.wait})")
+        if args.wait:
+            try:
+                wait_timestamp = int(args.wait)
+            except ValueError:
+                parser.error("--wait must be a unix timestamp integer.")
+
+            if wait_timestamp < time.time():
+                parser.error(f"Cannot wait for a timestamp in the past ({args.wait})")
 
     if args.command == "map":
-        Kartograf.map(args)
+        try:
+            Kartograf.map(args)
+        except KartografConfigurationError as error:
+            sys.exit(f"Error: {error}")
     elif args.command == "cov":
         Kartograf.cov(args)
     elif args.command == "merge":

--- a/kartograf/context.py
+++ b/kartograf/context.py
@@ -78,6 +78,7 @@ class Context:
         self.final_result_file = str(Path(self.out_dir) / "final_result.txt")
 
         self.max_encode = self.args.max_encode
+        self.rpki_backend = self.args.rpki_backend
 
         if self.args.debug:
             self.debug_log = str(Path(self.out_dir) / "debug.log")

--- a/kartograf/kartograf.py
+++ b/kartograf/kartograf.py
@@ -31,7 +31,7 @@ class Kartograf:
     def map(args):
         print_section_header("Start Kartograf")
         print("Kartograf version:", __version__)
-        check_compatibility()
+        check_compatibility(args.rpki_backend)
 
         if args.wait:
             wait_epoch = datetime.datetime.utcfromtimestamp(int(args.wait))

--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -6,7 +6,41 @@ import re
 import subprocess
 import time
 
-RPKI_VERSION = 9.7
+RPKI_VERSION = "9.7"
+RPKI_MAX_THREADS = 8
+
+
+class KartografConfigurationError(Exception):
+    """Raised when runtime configuration is invalid for map generation."""
+
+
+def _version_to_tuple(version):
+    if isinstance(version, tuple):
+        if len(version) < 2:
+            return None
+        try:
+            return int(version[0]), int(version[1])
+        except (TypeError, ValueError):
+            return None
+
+    if isinstance(version, str):
+        match = re.search(r"(\d+)\.(\d+)", version)
+        if not match:
+            return None
+        return int(match.group(1)), int(match.group(2))
+
+    if isinstance(version, (int, float)):
+        match = re.search(r"(\d+)\.(\d+)", str(version))
+        if not match:
+            return int(version), 0
+        return int(match.group(1)), int(match.group(2))
+
+    return None
+
+
+def _format_version(version_tuple):
+    major, minor = version_tuple
+    return f"{major}.{minor}"
 
 
 def calculate_sha256(file_path):
@@ -68,34 +102,79 @@ def get_rpki_local_version():
             r"rpki-client(?:-portable)? (\d+\.\d+)", result.stderr
         )
         if version_match:
-            version = version_match.group(1)
-            return float(version)
+            return version_match.group(1)
         return None
 
     except FileNotFoundError:
         return None
 
 
-def check_compatibility():
-    local_version = get_rpki_local_version()
-    latest_version = RPKI_VERSION
+def check_compatibility(rpki_backend="legacy"):
+    if rpki_backend not in {"legacy", "threaded"}:
+        raise KartografConfigurationError(
+            f"Unknown RPKI backend '{rpki_backend}'. Use 'legacy' or 'threaded'."
+        )
+
+    local_version_raw = get_rpki_local_version()
+    local_version = _version_to_tuple(local_version_raw)
+    latest_version = _version_to_tuple(RPKI_VERSION)
 
     if local_version is None:
-        raise RuntimeError("Could not determine rpki-client version. Is it installed?")
-    if local_version < 8.4:
-        raise Exception("Error: rpki-client version 8.4 or higher is required.")
+        raise KartografConfigurationError(
+            "Could not determine rpki-client version. Is it installed?"
+        )
+    if local_version < (8, 4):
+        raise KartografConfigurationError(
+            "rpki-client version 8.4 or higher is required."
+        )
+
+    if rpki_backend == "threaded" and local_version < (9, 6):
+        raise KartografConfigurationError(
+            "--rpki-backend threaded requires rpki-client version 9.6 or higher. "
+            "No automatic fallback to legacy backend is performed."
+        )
+
+    print(f"Selected RPKI backend: {rpki_backend}")
+
+    if rpki_backend == "legacy" and local_version >= (9, 6):
+        print(
+            "Notice: rpki-client 9.6+ detected, but using 'legacy' backend "
+            "for deterministic hashing. '--rpki-backend threaded' enables "
+            "the experimental threaded validation path."
+        )
 
     if local_version == latest_version:
-        print(f"Using rpki-client version {local_version} (recommended).")
+        print(
+            "Using rpki-client version "
+            f"{_format_version(local_version)} (recommended)."
+        )
     elif local_version > latest_version:
         print(
             "Warning: This kartograf version has not been tested with "
-            f"rpki-client versions higher than {latest_version}."
+            f"rpki-client versions higher than {_format_version(latest_version)}."
         )
     else:
         print(
-            f"Using rpki-client version {local_version}. Please beware that running with the latest tested version ({latest_version}) is recommend."
+            "Using rpki-client version "
+            f"{_format_version(local_version)}. Please beware that running "
+            "with the latest tested version "
+            f"({_format_version(latest_version)}) is recommended."
         )
+
+
+def get_rpki_thread_count(max_threads=RPKI_MAX_THREADS):
+    effective_max = max_threads
+    env_max_threads = os.getenv("RPKI_MAX_THREADS")
+    if env_max_threads:
+        try:
+            effective_max = min(max_threads, int(env_max_threads))
+        except ValueError:
+            # Ignore malformed overrides and fall back to configured defaults.
+            pass
+
+    effective_max = max(1, effective_max)
+    cpu_count = os.cpu_count() or 1
+    return max(1, min(cpu_count, effective_max))
 
 
 def wait_for_launch(wait):

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -2,7 +2,7 @@ import sys
 import re
 from importlib.metadata import distribution, PackageNotFoundError
 
-from kartograf.util import check_compatibility
+from kartograf.util import KartografConfigurationError, check_compatibility
 
 CHECK_MARK = "\U00002705"
 CROSS_MARK = "\U0000274C"
@@ -26,7 +26,7 @@ def __read_requirements_txt():
 def rpki_version():
     try:
         check_compatibility()
-    except RuntimeError as e:
+    except KartografConfigurationError as e:
         print(e)
 
 def python_version():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ def test_map_command(parser):
     assert args.routeviews is False  # default is False
     assert args.reproduce is None
     assert args.epoch is None
+    assert args.rpki_backend == 'legacy'
     assert args.max_encode == 33521664
 
 def test_reproduce_args_failure(capsys):
@@ -52,12 +53,31 @@ def test_stable_repos_flag(parser):
     args = parser.parse_args(['map', '--stable-repos'])
     assert args.stable_repos is True
 
+def test_rpki_backend_flag(parser):
+    args = parser.parse_args(['map'])
+    assert args.rpki_backend == 'legacy'
+
+    args = parser.parse_args(['map', '--rpki-backend', 'threaded'])
+    assert args.rpki_backend == 'threaded'
+
+def test_rpki_backend_help_mentions_threaded_status(parser):
+    map_parser = parser._subparsers._group_actions[0].choices['map']  # pylint: disable=protected-access
+    assert "requires rpki-client >= 9.6" in map_parser.format_help()
+
 def test_map_with_past_wait(capsys):
     args = ['map', '-w', '1225411200']
     with pytest.raises(SystemExit):
         main(args)
     captured = capsys.readouterr()
     assert "Cannot wait for a timestamp in the past (1225411200)" in captured.err
+
+
+def test_map_with_invalid_wait(capsys):
+    args = ['map', '-w', 'abc']
+    with pytest.raises(SystemExit):
+        main(args)
+    captured = capsys.readouterr()
+    assert "--wait must be a unix timestamp integer." in captured.err
 
 def test_merge_command(parser):
     args = parser.parse_args(['merge'])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,14 @@
 import pytest
-from kartograf.util import parse_pfx, is_valid_pfx, get_root_network, rir_from_str
+from types import SimpleNamespace
+
+from kartograf import util
+from kartograf.util import (
+    KartografConfigurationError,
+    parse_pfx,
+    is_valid_pfx,
+    get_root_network,
+    rir_from_str,
+)
 
 
 def test_valid_ipv4_network():
@@ -76,3 +85,64 @@ def test_rir_from_string():
     assert rir_from_str("apnic.db") == "APNIC"
     with pytest.raises(Exception):
         rir_from_str("invalid")
+
+
+def test_check_compatibility_rejects_invalid_backend():
+    with pytest.raises(KartografConfigurationError, match="Unknown RPKI backend"):
+        util.check_compatibility("invalid")
+
+
+def test_check_compatibility_threaded_requires_rpki_96(monkeypatch):
+    monkeypatch.setattr(util, "get_rpki_local_version", lambda: "9.5")
+    with pytest.raises(KartografConfigurationError, match="requires rpki-client version 9.6 or higher"):
+        util.check_compatibility("threaded")
+
+
+def test_check_compatibility_warns_when_legacy_on_96_plus(monkeypatch, capsys):
+    monkeypatch.setattr(util, "get_rpki_local_version", lambda: "9.6")
+    util.check_compatibility("legacy")
+
+    captured = capsys.readouterr()
+    assert "Notice: rpki-client 9.6+ detected" in captured.out
+
+
+def test_get_rpki_local_version_parses_two_digit_minor(monkeypatch):
+    def fake_run(*_args, **_kwargs):
+        return SimpleNamespace(stderr="rpki-client-portable 9.10")
+
+    monkeypatch.setattr(util.subprocess, "run", fake_run)
+
+    assert util.get_rpki_local_version() == "9.10"
+
+
+def test_check_compatibility_accepts_two_digit_minor(monkeypatch, capsys):
+    monkeypatch.setattr(util, "get_rpki_local_version", lambda: "9.10")
+
+    util.check_compatibility("threaded")
+
+    captured = capsys.readouterr()
+    assert "higher than 9.7" in captured.out
+
+
+def test_get_rpki_thread_count_caps_to_eight(monkeypatch):
+    monkeypatch.delenv("RPKI_MAX_THREADS", raising=False)
+    monkeypatch.setattr(util.os, "cpu_count", lambda: 128)
+    assert util.get_rpki_thread_count() == 8
+
+
+def test_get_rpki_thread_count_uses_cpu_count(monkeypatch):
+    monkeypatch.delenv("RPKI_MAX_THREADS", raising=False)
+    monkeypatch.setattr(util.os, "cpu_count", lambda: 4)
+    assert util.get_rpki_thread_count() == 4
+
+
+def test_get_rpki_thread_count_falls_back_to_one(monkeypatch):
+    monkeypatch.delenv("RPKI_MAX_THREADS", raising=False)
+    monkeypatch.setattr(util.os, "cpu_count", lambda: None)
+    assert util.get_rpki_thread_count() == 1
+
+
+def test_get_rpki_thread_count_honors_env_cap(monkeypatch):
+    monkeypatch.setenv("RPKI_MAX_THREADS", "3")
+    monkeypatch.setattr(util.os, "cpu_count", lambda: 16)
+    assert util.get_rpki_thread_count() == 3


### PR DESCRIPTION
This adds explicit RPKI backend selection so runtime behavior is intentional across rpki-client versions.

Main changes:
1) add --rpki-backend (legacy|threaded), defaulting to legacy
2) route backend choice through context/startup compatibility checks
3) enforce threaded backend version requirements with actionable configuration errors
4) improve --wait validation and cross-platform privilege checks
5) wire compatibility checks into scripts/check.py

Why:
issue #103 discusses rpki-client 9.6 compatibility tradeoffs. This keeps legacy deterministic by default and makes threaded intent explicit.

Validation:
-> pytest tests/test_cli.py tests/test_util.py -q
-> pytest tests/test_rpki_fetch.py tests/test_rpki_parser.py -q
-> pytest -q

Issue linkage:
- addresses #103