### PR TITLE
rpki: add threaded validation with normalized parity

### DIFF
--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -1,17 +1,20 @@
 import subprocess
 import sys
-
-from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
-from threading import Lock
+import os
+
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from pathlib import Path
 import requests
 from tqdm import tqdm
 
+from kartograf.rpki.normalize import normalize_rpki_json
 from kartograf.timed import timed
 from kartograf.util import (
+    KartografConfigurationError,
     calculate_sha256,
     calculate_sha256_directory,
+    get_rpki_thread_count,
 )
 
 TAL_URLS = {
@@ -37,6 +40,10 @@ STABLE_REPO_URLS = [
     "rpki.cnnic.cn",
     "repo-rpki.idnic.net"
 ]
+
+DEFAULT_RPKI_FETCH_TIMEOUT_SECONDS = 1800
+DEFAULT_RPKI_LEGACY_BATCH_TIMEOUT_SECONDS = 900
+DEFAULT_RPKI_THREADED_TIMEOUT_SECONDS = 1800
 
 def download_rir_tals(context):
     tals = []
@@ -68,6 +75,191 @@ def data_tals(context):
     sys.exit(1)
 
 
+def _get_timeout_seconds(env_var, default_seconds):
+    configured_value = os.getenv(env_var)
+    if not configured_value:
+        return default_seconds
+
+    try:
+        return max(1, int(configured_value))
+    except ValueError:
+        return default_seconds
+
+
+def _iter_concatenated_json_objects(payload):
+    decoder = json.JSONDecoder()
+    try:
+        text = payload.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise KartografConfigurationError(
+            "rpki-client legacy validation produced non-UTF-8 JSON output."
+        ) from exc
+    index = 0
+    text_length = len(text)
+
+    while index < text_length:
+        while index < text_length and text[index].isspace():
+            index += 1
+        if index >= text_length:
+            break
+
+        try:
+            parsed, index = decoder.raw_decode(text, index)
+        except json.JSONDecodeError as exc:
+            raise KartografConfigurationError(
+                "rpki-client legacy validation produced malformed concatenated JSON output."
+            ) from exc
+        yield parsed
+
+
+def _iter_bounded_legacy_batch_results(executor, process_files_batch, batches, max_in_flight):
+    batches_iter = iter(batches)
+    in_flight = set()
+
+    for _ in range(max_in_flight):
+        try:
+            in_flight.add(executor.submit(process_files_batch, next(batches_iter)))
+        except StopIteration:
+            break
+
+    while in_flight:
+        done, in_flight = wait(in_flight, return_when=FIRST_COMPLETED)
+
+        for completed in done:
+            yield completed.result()
+
+            try:
+                in_flight.add(executor.submit(process_files_batch, next(batches_iter)))
+            except StopIteration:
+                pass
+
+
+def _run_legacy_validation_to_temp(context, tal_options, files, temp_path):
+    batch_timeout = _get_timeout_seconds(
+        "KARTOGRAF_RPKI_LEGACY_BATCH_TIMEOUT_SECONDS",
+        DEFAULT_RPKI_LEGACY_BATCH_TIMEOUT_SECONDS,
+    )
+
+    def process_files_batch(batch):
+        try:
+            run_args = [
+                "rpki-client",
+                "-j",
+                "-n",
+                "-d",
+                context.data_dir_rpki_cache,
+                "-P",
+                context.epoch,
+            ] + tal_options + ["-f"] + batch
+
+            if context.debug_log:
+                with open(context.debug_log, "a", encoding="utf-8") as logs:
+                    return subprocess.run(
+                        run_args,
+                        stdout=subprocess.PIPE,
+                        stderr=logs,
+                        check=False,
+                        timeout=batch_timeout,
+                    )
+
+            return subprocess.run(
+                run_args,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                check=False,
+                timeout=batch_timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise KartografConfigurationError(
+                "rpki-client legacy validation timed out after "
+                f"{batch_timeout}s for a validation batch."
+            ) from exc
+
+    batch_size = 250
+    batches = []
+    for i in range(0, len(files), batch_size):
+        batches.append([str(f) for f in files[i:i + batch_size]])
+
+    with open(temp_path, "w", encoding="utf-8") as temp_out:
+        temp_out.write("[")
+        first_item = True
+
+        if batches:
+            workers = get_rpki_thread_count()
+            with ThreadPoolExecutor(max_workers=workers) as executor:
+                for result in tqdm(
+                    _iter_bounded_legacy_batch_results(executor, process_files_batch, batches, workers),
+                    total=len(batches),
+                ):
+
+                    if result.returncode != 0:
+                        raise KartografConfigurationError(
+                            f"rpki-client legacy validation failed with exit code {result.returncode}."
+                        )
+
+                    if not result.stdout:
+                        continue
+
+                    for parsed in _iter_concatenated_json_objects(result.stdout):
+                        if not first_item:
+                            temp_out.write(",")
+                        temp_out.write(json.dumps(parsed, separators=(",", ":")))
+                        first_item = False
+
+        temp_out.write("]")
+
+
+def _run_threaded_validation_to_temp(context, tal_options, temp_path):
+    threads = get_rpki_thread_count()
+    print(f"Using threaded rpki-client validation with {threads} worker(s).")
+    run_timeout = _get_timeout_seconds(
+        "KARTOGRAF_RPKI_THREADED_TIMEOUT_SECONDS",
+        DEFAULT_RPKI_THREADED_TIMEOUT_SECONDS,
+    )
+
+    run_args = [
+        "rpki-client",
+        "-j",
+        "-n",
+        "-d",
+        context.data_dir_rpki_cache,
+        "-P",
+        context.epoch,
+    ] + tal_options + ["-p", str(threads)]
+
+    try:
+        with open(temp_path, "w", encoding="utf-8") as temp_out:
+            if context.debug_log:
+                with open(context.debug_log, "a", encoding="utf-8") as logs:
+                    result = subprocess.run(
+                        run_args,
+                        stdout=temp_out,
+                        stderr=logs,
+                        check=False,
+                        text=True,
+                        timeout=run_timeout,
+                    )
+            else:
+                result = subprocess.run(
+                    run_args,
+                    stdout=temp_out,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                    text=True,
+                    timeout=run_timeout,
+                )
+    except subprocess.TimeoutExpired as exc:
+        raise KartografConfigurationError(
+            "rpki-client threaded validation timed out after "
+            f"{run_timeout}s."
+        ) from exc
+
+    if result.returncode != 0:
+        raise KartografConfigurationError(
+            f"rpki-client threaded validation failed with exit code {result.returncode}."
+        )
+
+
 @timed
 def fetch_rpki_db(context):
     # Download TALs and presist them in the RPKI data folder
@@ -75,86 +267,80 @@ def fetch_rpki_db(context):
     tal_options = [item for path in data_tals(context) for item in ('-t', path)]
     run_args = ["rpki-client", "-d", context.data_dir_rpki_cache] + tal_options
     print("Downloading RPKI Data, this may take a while.")
+    fetch_timeout = _get_timeout_seconds(
+        "KARTOGRAF_RPKI_FETCH_TIMEOUT_SECONDS",
+        DEFAULT_RPKI_FETCH_TIMEOUT_SECONDS,
+    )
 
     if context.stable_repos:
         for url in STABLE_REPO_URLS:
             run_args += ["-H", url]
         print("Using only stable RPKI repositories.")
 
-    if context.debug_log:
-        with open(context.debug_log, 'a') as logs:
-            logs.write("=== RPKI Download ===\n")
-            logs.flush()  # Without this the line above is not appearing first in the logs
-            subprocess.run(run_args,
-                           stdout=logs,
-                           stderr=logs,
-                           check=False)
-    else:
-        subprocess.run(run_args,
-                       capture_output=True,
-                       check=False)
+    try:
+        if context.debug_log:
+            with open(context.debug_log, 'a') as logs:
+                logs.write("=== RPKI Download ===\n")
+                logs.flush()  # Without this the line above is not appearing first in the logs
+                result = subprocess.run(run_args,
+                                        stdout=logs,
+                                        stderr=logs,
+                                        check=False,
+                                        timeout=fetch_timeout)
+        else:
+            result = subprocess.run(run_args,
+                                    stdout=subprocess.DEVNULL,
+                                    stderr=subprocess.DEVNULL,
+                                    check=False,
+                                    timeout=fetch_timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise KartografConfigurationError(
+            f"rpki-client data fetch timed out after {fetch_timeout}s."
+        ) from exc
+
+    if result.returncode != 0:
+        raise KartografConfigurationError(
+            f"rpki-client data fetch failed with exit code {result.returncode}."
+        )
 
     print(f"Downloaded RPKI Data, hash sum: {calculate_sha256_directory(context.data_dir_rpki_cache)}")
 
 
 @timed
 def validate_rpki_db(context):
-    files = [path for path in Path(context.data_dir_rpki_cache).rglob('*')
-             if path.is_file() and ((path.suffix == ".roa")
-                                    or (path.name == ".roa"))]
+    backend = getattr(context, "rpki_backend", "legacy")
+    if backend not in {"legacy", "threaded"}:
+        raise KartografConfigurationError(
+            f"Unsupported RPKI backend '{backend}'. Use 'legacy' or 'threaded'."
+        )
 
-    print(f"{len(files)} raw RKPI ROA files found.")
+    files = []
+    if backend == "legacy":
+        files = [path for path in Path(context.data_dir_rpki_cache).rglob('*')
+                 if path.is_file() and ((path.suffix == ".roa")
+                                        or (path.name == ".roa"))]
+
+        print(f"{len(files)} raw RPKI ROA files found.")
     rpki_raw_file = 'rpki_raw.json'
     result_path = Path(context.out_dir_rpki) / rpki_raw_file
+    temp_path = Path(context.out_dir_rpki) / "rpki_temp.json"
 
     tal_options = [item for path in data_tals(context) for item in ('-t', path)]
-
-    debug_file_lock = Lock()
 
     if context.debug_log:
         with open(context.debug_log, 'a') as logs:
             logs.write("\n\n=== RPKI Validation ===\n")
 
-    def process_files_batch(batch):
-        result = subprocess.run(["rpki-client",
-                                 "-j",
-                                 "-n",
-                                 "-d",
-                                 context.data_dir_rpki_cache,
-                                 "-P",
-                                 context.epoch,
-                                 ] + tal_options +
-                                 ["-f"] + batch,  # -f has to be last
-                                 capture_output=True,
-                                 check=False)
+    if backend == "legacy":
+        _run_legacy_validation_to_temp(context, tal_options, files, temp_path)
+    else:
+        _run_threaded_validation_to_temp(context, tal_options, temp_path)
 
-        if result.stderr and context.debug_log:
-            stderr_output = result.stderr.decode()
-            with debug_file_lock:
-                with open(context.debug_log, 'a') as logs:
-                    logs.write(stderr_output)
-        return result.stdout
+    records_count = normalize_rpki_json(temp_path, result_path)
+    context.cleanup_out_files.append(temp_path)
 
-    total = len(files)
-    batch_size = 250
-    batches = []
-    for i in range(0, total, batch_size):
-        batch = [str(f) for f in files[i:i + batch_size]]
-        batches.append(batch)
-
-    total_batches = len(batches)
-    results = []
-    with ThreadPoolExecutor() as executor:
-        futures = [executor.submit(process_files_batch, batch) for batch in batches]
-        for future in tqdm(as_completed(futures), total=total_batches):
-            result = future.result()
-            if result:
-                normalized = result.replace(b"\n}\n{\n\t", b"\n},\n{\n").decode('utf-8').strip()
-                results.append(normalized)
-        results_json = json.loads("[" + ",".join(results) + "]")
-        s = sorted(results_json, key=lambda result: result["hash_id"])
-
-        with open(result_path, 'w') as f:
-            json.dump(s, f)
-
-    print(f"{len(results_json)} RKPI ROAs validated\nSaved to: {result_path.name}\nFile hash: {calculate_sha256(result_path)}")
+    print(
+        f"{records_count} RPKI ROA records normalized\n"
+        f"Saved to: {result_path.name}\n"
+        f"File hash: {calculate_sha256(result_path)}"
+    )

--- a/kartograf/rpki/normalize.py
+++ b/kartograf/rpki/normalize.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+from typing import Iterator, NamedTuple
+
+import ijson
+
+from kartograf.util import parse_pfx
+
+
+class NormalizedROA(NamedTuple):
+    prefix: str
+    asn: int
+    expires: int
+
+
+def _safe_int(value):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _detect_root_json_type(input_path: Path) -> str:
+    with open(input_path, "rb") as src:
+        while True:
+            char = src.read(1)
+            if not char:
+                return ""
+            if not char.isspace():
+                return char.decode("utf-8", errors="ignore")
+
+
+def _normalize_legacy_roa(roa: dict) -> Iterator[NormalizedROA]:
+    if roa.get("type") != "roa" or roa.get("validation") != "OK":
+        return
+
+    # Legacy objects can include both valid_until and expires.
+    # Prefer expires when available to match threaded output semantics.
+    expires = _safe_int(roa.get("expires", roa.get("valid_until")))
+    if expires is None:
+        return
+
+    for vrp in roa.get("vrps", []):
+        prefix_raw = vrp.get("prefix")
+        if not isinstance(prefix_raw, str):
+            continue
+
+        prefix = parse_pfx(prefix_raw)
+        asn = _safe_int(vrp.get("asid"))
+        if prefix and asn is not None:
+            yield NormalizedROA(prefix=prefix, asn=asn, expires=expires)
+
+
+def _normalize_threaded_roa(roa: dict) -> Iterator[NormalizedROA]:
+    prefix_raw = roa.get("prefix")
+    if not isinstance(prefix_raw, str):
+        return
+
+    prefix = parse_pfx(prefix_raw)
+    asn = _safe_int(roa.get("asn"))
+    expires = _safe_int(roa.get("expires", roa.get("expiry")))
+
+    if prefix and asn is not None and expires is not None:
+        yield NormalizedROA(prefix=prefix, asn=asn, expires=expires)
+
+
+def iter_normalized_roas(input_path: Path) -> Iterator[NormalizedROA]:
+    root_type = _detect_root_json_type(input_path)
+    if root_type == "[":
+        with open(input_path, "rb") as src:
+            for roa in ijson.items(src, "item"):
+                yield from _normalize_legacy_roa(roa)
+        return
+
+    if root_type == "{":
+        with open(input_path, "rb") as src:
+            for roa in ijson.items(src, "roas.item"):
+                yield from _normalize_threaded_roa(roa)
+        return
+
+    raise ValueError(f"Unsupported RPKI JSON format in {input_path}")
+
+
+def normalize_rpki_json(input_path: Path, output_path: Path) -> int:
+    normalized = sorted(iter_normalized_roas(input_path), key=lambda roa: (roa.prefix, roa.asn, roa.expires))
+
+    with open(output_path, "w", encoding="utf-8") as out:
+        out.write("[")
+        for idx, roa in enumerate(normalized):
+            if idx > 0:
+                out.write(",")
+            out.write(
+                json.dumps(
+                    {"prefix": roa.prefix, "asn": roa.asn, "expires": roa.expires},
+                    separators=(",", ":"),
+                )
+            )
+        out.write("]")
+
+    return len(normalized)

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -1,6 +1,8 @@
-import json
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Tuple
+
+import ijson
+from ijson.common import IncompleteJSONError, JSONError
 
 from kartograf.bogon import (
     is_bogon_pfx,
@@ -8,7 +10,7 @@ from kartograf.bogon import (
     is_out_of_encoding_range,
 )
 from kartograf.timed import timed
-from kartograf.util import parse_pfx
+from kartograf.util import KartografConfigurationError, parse_pfx
 
 
 @timed
@@ -16,91 +18,78 @@ def parse_rpki(context):
     raw_input = Path(context.out_dir_rpki) / "rpki_raw.json"
     rpki_res = Path(context.out_dir_rpki) / "rpki_final.txt"
 
-    output_cache: Dict[str, [str, str]] = {}
+    output_cache: Dict[str, Tuple[int, int]] = {}
 
     dups_count = 0
     out_count = 0
     invalids = 0
     incompletes = 0
-    not_roas = 0
+    total_records = 0
 
-    with open(raw_input, "r") as dump:
-        data = json.loads(dump.read())
-        print(f'Parsing {len(data)} ROAs')
+    print("Parsing normalized ROA records")
 
-        for roa in data:
-            # Sometimes ROAs are incomplete and we have to skip them
-            key_list = [
-                'type',
-                'validation',
-                'aki',
-                'ski',
-                'vrps',
-                'valid_until'
-            ]
-            if not all(key in roa for key in key_list):
-                incompletes += 1
-                continue
+    try:
+        with open(raw_input, "rb") as dump:
+            for roa in ijson.items(dump, "item"):
+                total_records += 1
 
-            # We are only interested in ROAs
-            if roa['type'] != "roa":
-                not_roas += 1
-                continue
+                if not isinstance(roa, dict):
+                    incompletes += 1
+                    continue
 
-            # We are only interested in valid ROAs
-            if roa['validation'] != "OK":
-                invalids += 1
-                continue
+                key_list = ["prefix", "asn", "expires"]
+                if not all(key in roa for key in key_list):
+                    incompletes += 1
+                    continue
 
-            valid_until = roa['valid_until']
-            valid_since = roa['valid_since']
-
-            for vrp in roa['vrps']:
-                asn = vrp['asid']
-                prefix = parse_pfx(vrp['prefix'])
+                prefix = parse_pfx(roa["prefix"])
                 if not prefix:
                     if context.debug_log:
                         with open(context.debug_log, 'a') as logs:
-                            logs.write(f"Could not parse prefix from line: {vrp['prefix']}")
+                            logs.write(f"Could not parse prefix from line: {roa['prefix']}\n")
+                    invalids += 1
                     continue
+
+                try:
+                    asn = int(roa["asn"])
+                    expires = int(roa["expires"])
+                except (TypeError, ValueError):
+                    incompletes += 1
+                    continue
+
                 # Bogon prefixes and ASNs are excluded since they can not
                 # be used for routing.
                 if is_bogon_pfx(prefix) or is_bogon_asn(asn):
                     if context.debug_log:
                         with open(context.debug_log, 'a') as logs:
                             logs.write(f"RPKI: parser encountered an invalid IP network: {prefix}\n")
+                    invalids += 1
                     continue
 
                 if context.max_encode and is_out_of_encoding_range(asn, context.max_encode):
                     continue
 
                 # Multiple ROAs for the same prefix are possible and we need
-                # to decide if we update the entry or not
-                if output_cache.get(prefix):
+                # deterministic tie-breaking that works for both legacy and
+                # threaded backends.
+                if prefix in output_cache:
                     dups_count += 1
-                    # If the new ASN is from a ROA that is valid for longer,
-                    # we override the old entry with it
-                    [old_asn, old_valid_until, old_valid_since] = output_cache[prefix]
-                    if int(valid_until) > int(old_valid_until):
-                        output_cache[prefix] = [asn, valid_until, valid_since]
-                    # If the entries have the same validity period, we need to
-                    # choose a different tie breaker
-                    if int(valid_until) == int(old_valid_until):
-                        # Prefer the ROA that was announced last
-                        if int(valid_since) > int(old_valid_since):
-                            output_cache[prefix] = [asn, valid_until, valid_since]
-                        # If the ROAs were also announced at the same time, we
-                        # fall back to using the lower ASN just to be
-                        # deterministic
-                        if int(valid_since) == int(old_valid_since):
-                            if int(asn) < int(old_asn):
-                                output_cache[prefix] = [asn, valid_until, valid_since]
+                    old_asn, old_expires = output_cache[prefix]
+
+                    if expires > old_expires:
+                        output_cache[prefix] = (asn, expires)
+                    elif expires == old_expires and asn < old_asn:
+                        output_cache[prefix] = (asn, expires)
                 else:
-                    # No duplicate, add to cache
-                    output_cache[prefix] = [asn, valid_until, valid_since]
+                    output_cache[prefix] = (asn, expires)
+    except (JSONError, IncompleteJSONError) as exc:
+        raise KartografConfigurationError(
+            "Malformed or truncated rpki_raw.json detected. "
+            "Re-run validation to regenerate normalized RPKI data."
+        ) from exc
 
     with open(rpki_res, "w") as asmap:
-        for prefix, [asn, _, _] in output_cache.items():
+        for prefix, (asn, _) in sorted(output_cache.items()):
             line_out = f"{prefix} AS{asn}"
 
             asmap.write(line_out + '\n')
@@ -108,8 +97,8 @@ def parse_rpki(context):
 
     context.cleanup_out_files.append(raw_input)
 
+    print(f'Total records processed: {total_records}')
     print(f'Result entries written: {out_count}')
     print(f'Duplicates found: {dups_count}')
     print(f'Invalids found: {invalids}')
     print(f'Incompletes: {incompletes}')
-    print(f'Non-ROA files: {not_roas}')

--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -7,6 +7,11 @@ import subprocess
 import time
 
 RPKI_VERSION = 9.7
+RPKI_MAX_THREADS = 8
+
+
+class KartografConfigurationError(Exception):
+    """Raised when runtime configuration is invalid for map generation."""
 
 
 def calculate_sha256(file_path):
@@ -136,6 +141,9 @@ def parse_pfx(pfx):
     Attempt to format an IP network or address.
     If invalid, return None.
     """
+    if not isinstance(pfx, str):
+        return None
+
     if is_valid_pfx(pfx):
         if "/" in pfx:
             formatted_pfx = str(ipaddress.ip_network(pfx))
@@ -154,8 +162,23 @@ def is_valid_pfx(pfx):
             return True
         ipaddress.ip_address(pfx)
         return True
-    except ValueError:
+    except (TypeError, ValueError):
         return False
+
+
+def get_rpki_thread_count(max_threads=RPKI_MAX_THREADS):
+    effective_max = max_threads
+    env_max_threads = os.getenv("RPKI_MAX_THREADS")
+    if env_max_threads:
+        try:
+            effective_max = min(max_threads, int(env_max_threads))
+        except ValueError:
+            # Ignore malformed overrides and fall back to configured defaults.
+            pass
+
+    effective_max = max(1, effective_max)
+    cpu_count = os.cpu_count() or 1
+    return max(1, min(cpu_count, effective_max))
 
 
 def get_root_network(pfx):

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4>=4.11.1
 pandas>=2.2.3
 requests>=2.31.0
 tqdm>=4.67.0
+ijson>=3.3.0

--- a/tests/context.py
+++ b/tests/context.py
@@ -14,6 +14,7 @@ TEST_ARGS = SimpleNamespace(**{
     "max_encode": 33521664,
     "debug": False,
     "stable_repos": False,
+    "rpki_backend": "legacy",
     "wipe_data_dir": False,
     "cleanup_out_files": [],
     "epoch": None
@@ -29,15 +30,20 @@ def load_rpki_csv_to_json(context, fixtures_path):
     '''
     csv_path = fixtures_path / "rpki_raw.csv"
     rpki_data = []
-    with open(csv_path, 'r') as csvfile:
+    with open(csv_path, 'r', encoding='utf-8') as csvfile:
         reader = csv.DictReader(csvfile)
         for row in reader:
-            vrps = [{"prefix": row["prefix"], "asid": row["asid"], "maxlen": row["maxlen"]}]
-            del row["prefix"]
-            del row["asid"]
-            del row["maxlen"]
-            row["vrps"] = vrps
-            rpki_data.append(row)
+            # Match the normalized schema produced by rpki validation.
+            if row.get("type") != "roa" or row.get("validation") != "OK":
+                continue
+
+            rpki_data.append(
+                {
+                    "prefix": row["prefix"],
+                    "asn": int(row["asid"]),
+                    "expires": int(row["valid_until"]),
+                }
+            )
 
     output_path = Path(context.out_dir_rpki) / 'rpki_raw.json'
     with open(output_path, 'w') as jsonfile:

--- a/tests/test_rpki_fetch.py
+++ b/tests/test_rpki_fetch.py
@@ -1,0 +1,182 @@
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from kartograf.rpki.fetch import validate_rpki_db
+from kartograf.util import KartografConfigurationError, calculate_sha256
+
+
+def _create_context(tmp_path, backend):
+    cache = tmp_path / f"cache_{backend}"
+    tals = tmp_path / f"tals_{backend}"
+    out = tmp_path / f"out_{backend}"
+
+    cache.mkdir(parents=True, exist_ok=True)
+    tals.mkdir(parents=True, exist_ok=True)
+    out.mkdir(parents=True, exist_ok=True)
+
+    # The legacy flow validates discovered .roa files with -f batches.
+    (cache / "sample.roa").write_text("dummy", encoding="utf-8")
+
+    # data_tals() requires all five TAL files to be present.
+    for tal in ["afrinic", "apnic", "arin", "lacnic", "ripe"]:
+        (tals / f"{tal}.tal").write_text("tal", encoding="utf-8")
+
+    return SimpleNamespace(
+        rpki_backend=backend,
+        data_dir_rpki_cache=str(cache),
+        data_dir_rpki_tals=str(tals),
+        out_dir_rpki=str(out),
+        epoch="111111114",
+        debug_log=None,
+        cleanup_out_files=[],
+    )
+
+
+def test_validate_rpki_db_legacy_threaded_parity(tmp_path, monkeypatch):
+    legacy_context = _create_context(tmp_path, "legacy")
+    threaded_context = _create_context(tmp_path, "threaded")
+
+    legacy_roa = (
+        b'{"type":"roa","validation":"OK","valid_until":200,'
+        b'"vrps":[{"prefix":"101.0.1.0/24","asid":11102,"maxlen":24}]}'
+    )
+    threaded_payload = {
+        "roas": [
+            {
+                "prefix": "101.0.1.0/24",
+                "asn": 11102,
+                "maxLength": 24,
+                "ta": "arin",
+                "expires": 200,
+            }
+        ]
+    }
+
+    def fake_run_legacy(cmd, check=False, **_kwargs):
+        assert "-f" in cmd
+        assert check is False
+        return SimpleNamespace(stdout=legacy_roa, stderr=b"", returncode=0)
+
+    monkeypatch.setattr("kartograf.rpki.fetch.subprocess.run", fake_run_legacy)
+    validate_rpki_db(legacy_context)
+
+    legacy_raw = Path(legacy_context.out_dir_rpki) / "rpki_raw.json"
+    legacy_hash = calculate_sha256(legacy_raw)
+
+    def fake_run_threaded(cmd, stdout=None, stderr=None, check=False, text=False, **_kwargs):
+        assert "-p" in cmd
+        assert stdout is not None
+        assert stderr is not None
+        assert check is False
+        assert text is True
+        json.dump(threaded_payload, stdout)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr("kartograf.rpki.fetch.subprocess.run", fake_run_threaded)
+    validate_rpki_db(threaded_context)
+
+    threaded_raw = Path(threaded_context.out_dir_rpki) / "rpki_raw.json"
+    threaded_hash = calculate_sha256(threaded_raw)
+
+    with open(legacy_raw, "r", encoding="utf-8") as f_legacy:
+        legacy_data = json.load(f_legacy)
+    with open(threaded_raw, "r", encoding="utf-8") as f_threaded:
+        threaded_data = json.load(f_threaded)
+
+    assert legacy_data == threaded_data
+    assert legacy_hash == threaded_hash
+
+
+def test_validate_rpki_db_threaded_uses_bounded_workers(tmp_path, monkeypatch):
+    context = _create_context(tmp_path, "threaded")
+    commands = []
+
+    # Even very large CPU counts should be clamped by get_rpki_thread_count().
+    monkeypatch.setattr("kartograf.util.os.cpu_count", lambda: 128)
+
+    def fake_run_threaded(cmd, stdout=None, stderr=None, check=False, text=False, **_kwargs):
+        commands.append(cmd)
+        json.dump({"roas": []}, stdout)
+        return SimpleNamespace(stdout="", stderr="", returncode=0)
+
+    monkeypatch.setattr("kartograf.rpki.fetch.subprocess.run", fake_run_threaded)
+    validate_rpki_db(context)
+
+    assert commands, "Expected rpki-client to be executed"
+    cmd = commands[0]
+    assert "-p" in cmd
+    thread_flag_index = cmd.index("-p")
+    assert cmd[thread_flag_index + 1] == "8"
+
+
+def test_validate_rpki_db_legacy_raises_on_subprocess_error(tmp_path, monkeypatch):
+    context = _create_context(tmp_path, "legacy")
+
+    def fake_run_legacy(_cmd, **_kwargs):
+        return SimpleNamespace(stdout=b"", stderr=b"error", returncode=1)
+
+    monkeypatch.setattr("kartograf.rpki.fetch.subprocess.run", fake_run_legacy)
+
+    with pytest.raises(KartografConfigurationError, match="legacy validation failed"):
+        validate_rpki_db(context)
+
+
+def test_validate_rpki_db_threaded_raises_on_subprocess_error(tmp_path, monkeypatch):
+    context = _create_context(tmp_path, "threaded")
+
+    def fake_run_threaded(_cmd, stdout=None, **_kwargs):
+        json.dump({"roas": []}, stdout)
+        return SimpleNamespace(stdout="", stderr="error", returncode=2)
+
+    monkeypatch.setattr("kartograf.rpki.fetch.subprocess.run", fake_run_threaded)
+
+    with pytest.raises(KartografConfigurationError, match="threaded validation failed"):
+        validate_rpki_db(context)
+
+
+def test_validate_rpki_db_legacy_raises_on_malformed_batch_output(tmp_path, monkeypatch):
+    context = _create_context(tmp_path, "legacy")
+
+    def fake_run_legacy(_cmd, **_kwargs):
+        return SimpleNamespace(stdout=b'{"type":"roa"', stderr=b"", returncode=0)
+
+    monkeypatch.setattr("kartograf.rpki.fetch.subprocess.run", fake_run_legacy)
+
+    with pytest.raises(KartografConfigurationError, match="malformed concatenated JSON output"):
+        validate_rpki_db(context)
+
+
+def test_validate_rpki_db_legacy_raises_on_timeout(tmp_path, monkeypatch):
+    context = _create_context(tmp_path, "legacy")
+
+    def fake_run_legacy(_cmd, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="rpki-client", timeout=1)
+
+    monkeypatch.setattr("kartograf.rpki.fetch.subprocess.run", fake_run_legacy)
+
+    with pytest.raises(KartografConfigurationError, match="legacy validation timed out"):
+        validate_rpki_db(context)
+
+
+def test_validate_rpki_db_threaded_raises_on_timeout(tmp_path, monkeypatch):
+    context = _create_context(tmp_path, "threaded")
+
+    def fake_run_threaded(_cmd, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd="rpki-client", timeout=1)
+
+    monkeypatch.setattr("kartograf.rpki.fetch.subprocess.run", fake_run_threaded)
+
+    with pytest.raises(KartografConfigurationError, match="threaded validation timed out"):
+        validate_rpki_db(context)
+
+
+@pytest.mark.parametrize("backend", ["", "future"])
+def test_validate_rpki_db_rejects_unknown_backend(tmp_path, backend):
+    context = _create_context(tmp_path, backend)
+
+    with pytest.raises(KartografConfigurationError, match="Unsupported RPKI backend"):
+        validate_rpki_db(context)

--- a/tests/test_rpki_normalize.py
+++ b/tests/test_rpki_normalize.py
@@ -1,0 +1,143 @@
+import json
+
+import pytest
+
+from kartograf.rpki.normalize import normalize_rpki_json
+
+
+def test_normalize_legacy_filters_and_orders(tmp_path):
+    input_path = tmp_path / "legacy.json"
+    output_path = tmp_path / "normalized.json"
+
+    legacy_payload = [
+        {
+            "type": "roa",
+            "validation": "OK",
+            "valid_until": 100,
+            "vrps": [
+                {"prefix": "2.2.2.0/24", "asid": 64500, "maxlen": 24},
+                {"prefix": "1.1.1.0/24", "asid": 13335, "maxlen": 24},
+            ],
+        },
+        {
+            "type": "roa",
+            "validation": "FAIL",
+            "valid_until": 100,
+            "vrps": [{"prefix": "3.3.3.0/24", "asid": 64501, "maxlen": 24}],
+        },
+        {
+            "type": "manifest",
+            "validation": "OK",
+            "valid_until": 100,
+            "vrps": [{"prefix": "4.4.4.0/24", "asid": 64502, "maxlen": 24}],
+        },
+    ]
+
+    with open(input_path, "w", encoding="utf-8") as f:
+        json.dump(legacy_payload, f)
+
+    count = normalize_rpki_json(input_path, output_path)
+
+    with open(output_path, "r", encoding="utf-8") as f:
+        normalized = json.load(f)
+
+    assert count == 2
+    assert normalized == [
+        {"prefix": "1.1.1.0/24", "asn": 13335, "expires": 100},
+        {"prefix": "2.2.2.0/24", "asn": 64500, "expires": 100},
+    ]
+
+
+def test_normalize_legacy_prefers_expires_when_present(tmp_path):
+    input_path = tmp_path / "legacy_with_expires.json"
+    output_path = tmp_path / "normalized.json"
+
+    legacy_payload = [
+        {
+            "type": "roa",
+            "validation": "OK",
+            "valid_until": 999,
+            "expires": 123,
+            "vrps": [
+                {"prefix": "1.1.1.0/24", "asid": 13335, "maxlen": 24},
+            ],
+        }
+    ]
+
+    with open(input_path, "w", encoding="utf-8") as f:
+        json.dump(legacy_payload, f)
+
+    count = normalize_rpki_json(input_path, output_path)
+
+    with open(output_path, "r", encoding="utf-8") as f:
+        normalized = json.load(f)
+
+    assert count == 1
+    assert normalized == [
+        {"prefix": "1.1.1.0/24", "asn": 13335, "expires": 123},
+    ]
+
+
+def test_normalize_threaded_supports_expiry_alias(tmp_path):
+    input_path = tmp_path / "threaded.json"
+    output_path = tmp_path / "normalized.json"
+
+    threaded_payload = {
+        "roas": [
+            {"prefix": "9.9.9.0/24", "asn": 19281, "expiry": 222},
+            {"prefix": "8.8.8.0/24", "asn": 15169, "expires": 333},
+        ]
+    }
+
+    with open(input_path, "w", encoding="utf-8") as f:
+        json.dump(threaded_payload, f)
+
+    count = normalize_rpki_json(input_path, output_path)
+
+    with open(output_path, "r", encoding="utf-8") as f:
+        normalized = json.load(f)
+
+    assert count == 2
+    assert normalized == [
+        {"prefix": "8.8.8.0/24", "asn": 15169, "expires": 333},
+        {"prefix": "9.9.9.0/24", "asn": 19281, "expires": 222},
+    ]
+
+
+def test_normalize_rejects_unknown_root_json(tmp_path):
+    input_path = tmp_path / "invalid.json"
+    output_path = tmp_path / "normalized.json"
+
+    input_path.write_text('"unexpected"', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Unsupported RPKI JSON format"):
+        normalize_rpki_json(input_path, output_path)
+
+
+def test_normalize_skips_non_string_prefix_values(tmp_path):
+    input_path = tmp_path / "legacy_bad_prefix.json"
+    output_path = tmp_path / "normalized.json"
+
+    payload = [
+        {
+            "type": "roa",
+            "validation": "OK",
+            "valid_until": 100,
+            "vrps": [
+                {"prefix": None, "asid": 64500, "maxlen": 24},
+                {"prefix": 123, "asid": 64501, "maxlen": 24},
+                {"prefix": "1.1.1.0/24", "asid": 13335, "maxlen": 24},
+            ],
+        }
+    ]
+
+    with open(input_path, "w", encoding="utf-8") as f:
+        json.dump(payload, f)
+
+    count = normalize_rpki_json(input_path, output_path)
+
+    with open(output_path, "r", encoding="utf-8") as f:
+        normalized = json.load(f)
+
+    assert count == 1
+    assert normalized == [{"prefix": "1.1.1.0/24", "asn": 13335, "expires": 100}]

--- a/tests/test_rpki_parser.py
+++ b/tests/test_rpki_parser.py
@@ -1,7 +1,9 @@
 import json
 import os
+import pytest
 
 from kartograf.rpki.parse import parse_rpki
+from kartograf.util import KartografConfigurationError
 from .context import create_test_context, setup_test_data
 
 
@@ -39,9 +41,8 @@ def test_roa_validations(tmp_path, capsys):
     assert len(final_lines) == 10, "Should have found 10 valid ROAs"
     assert "Result entries written: 10" in captured.out
     assert "Duplicates found: 5" in captured.out
-    assert "Invalids found: 1" in captured.out
+    assert "Invalids found: 0" in captured.out
     assert "Incompletes: 0" in captured.out
-    assert "Non-ROA files: 1" in captured.out
 
 def test_roa_incompletes(tmp_path, capsys):
     '''
@@ -52,20 +53,12 @@ def test_roa_incompletes(tmp_path, capsys):
     context = create_test_context(tmp_path, epoch)
     test_data = [
         {
-            "type": "roa",
-            "validation": "OK",
-            "ski": "some-ski",
-            "vrps": [{"prefix": "192.0.2.0/24", "asid": "64496", "maxlen": "24"}],
-            "valid_until": "1234567890",
-            "valid_since": "1234567880"
+            "prefix": "192.0.2.0/24",
+            "asn": "64496",
         },
         {
-            "type": "roa",
-            "validation": "OK",
-            "ski": "some-ski",
-            "vrps": [{"prefix": "198.51.100.0/24", "asid": "64497", "maxlen": "24"}],
-            "valid_until": "1234567890",
-            "valid_since": "1234567880"
+            "prefix": "198.51.100.0/24",
+            "expires": "1234567890",
         }
     ]
 
@@ -88,6 +81,42 @@ def test_roa_incompletes(tmp_path, capsys):
     assert "Incompletes: 2" in captured.out
 
 
+def test_roa_invalid_and_incomplete_counters(tmp_path, capsys):
+    epoch = "111111113"
+    context = create_test_context(tmp_path, epoch)
+    test_data = [
+        {
+            "prefix": "1.1.1.0/24",
+            "asn": 13335,
+            "expires": 1234567890,
+        },
+        {
+            "prefix": "10.0.0.0/8",
+            "asn": 13335,
+            "expires": 1234567890,
+        },
+        {
+            "prefix": "2.2.2.0/24",
+            "asn": "not_an_int",
+            "expires": 1234567890,
+        },
+    ]
+
+    with open(os.path.join(context.out_dir_rpki, "rpki_raw.json"), "w") as f:
+        json.dump(test_data, f)
+
+    parse_rpki(context)
+
+    final_path = os.path.join(context.out_dir_rpki, "rpki_final.txt")
+    with open(final_path, "r") as f:
+        final_lines = [line.strip() for line in f.readlines()]
+
+    captured = capsys.readouterr()
+    assert final_lines == ["1.1.1.0/24 AS13335"]
+    assert "Invalids found: 1" in captured.out
+    assert "Incompletes: 1" in captured.out
+
+
 def test_roa_valid_until_fallback(tmp_path):
     '''Test ROA selection falls back to later valid_until'''
     epoch = "111111111"
@@ -104,7 +133,7 @@ def test_roa_valid_until_fallback(tmp_path):
 
 
 def test_roa_valid_since_fallback(tmp_path):
-    '''Test ROA selection falls back to later valid_since when valid_until matches'''
+    '''When expires match, strict parity fallback selects lowest ASN.'''
     epoch = "111111111"
     context = create_test_context(tmp_path, epoch)
     setup_test_data(context)
@@ -114,8 +143,8 @@ def test_roa_valid_since_fallback(tmp_path):
     with open(final_path, "r") as f:
         entries = [line.strip() for line in f.readlines()]
 
-    assert "102.0.100.0/24 AS11104" in entries, "ROA with later valid_since should be selected"
-    assert not any("102.0.100.0/24 AS11103" in e for e in entries), "ROA with earlier valid_since should not be selected"
+    assert "102.0.100.0/24 AS11103" in entries, "ROA with lower ASN should be selected when expires match"
+    assert not any("102.0.100.0/24 AS11104" in e for e in entries), "ROA with higher ASN should not be selected when expires match"
 
 
 def test_roa_asn_fallback(tmp_path):
@@ -131,3 +160,51 @@ def test_roa_asn_fallback(tmp_path):
 
     assert "103.0.1.0/24 AS11105" in entries, "ROA with lower ASN should be selected"
     assert not any("103.0.1.0/24 AS11106" in e for e in entries), "ROA with higher ASN should not be selected"
+
+
+def test_parse_rpki_accepts_threaded_context(tmp_path):
+    epoch = "111111114"
+    context = create_test_context(tmp_path, epoch)
+    context.rpki_backend = "threaded"
+    setup_test_data(context)
+
+    parse_rpki(context)
+
+    final_path = os.path.join(context.out_dir_rpki, "rpki_final.txt")
+    assert os.path.exists(final_path)
+
+
+def test_parse_rpki_rejects_truncated_json(tmp_path):
+    epoch = "111111115"
+    context = create_test_context(tmp_path, epoch)
+
+    raw_path = os.path.join(context.out_dir_rpki, "rpki_raw.json")
+    with open(raw_path, "w", encoding="utf-8") as f:
+        f.write('[{"prefix":"1.1.1.0/24","asn":13335,"expires":1234567890}')
+
+    with pytest.raises(KartografConfigurationError, match="Malformed or truncated rpki_raw.json"):
+        parse_rpki(context)
+
+
+def test_parse_rpki_handles_non_string_prefix_values(tmp_path, capsys):
+    epoch = "111111116"
+    context = create_test_context(tmp_path, epoch)
+
+    test_data = [
+        {"prefix": None, "asn": 64496, "expires": 1},
+        {"prefix": 123, "asn": 64497, "expires": 1},
+        {"prefix": "1.1.1.0/24", "asn": 13335, "expires": 1},
+    ]
+
+    with open(os.path.join(context.out_dir_rpki, "rpki_raw.json"), "w", encoding="utf-8") as f:
+        json.dump(test_data, f)
+
+    parse_rpki(context)
+
+    final_path = os.path.join(context.out_dir_rpki, "rpki_final.txt")
+    with open(final_path, "r", encoding="utf-8") as f:
+        final_lines = [line.strip() for line in f.readlines()]
+
+    captured = capsys.readouterr()
+    assert final_lines == ["1.1.1.0/24 AS13335"]
+    assert "Invalids found: 2" in captured.out

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,11 @@
 import pytest
-from kartograf.util import parse_pfx, is_valid_pfx, get_root_network, rir_from_str
+from kartograf.util import (
+    get_root_network,
+    get_rpki_thread_count,
+    is_valid_pfx,
+    parse_pfx,
+    rir_from_str,
+)
 
 
 def test_valid_ipv4_network():
@@ -30,6 +36,13 @@ def test_invalid_ip_network():
 def test_invalid_input():
     pfx = "no.slash"
     assert parse_pfx(pfx) is None
+
+
+def test_non_string_prefix_input():
+    assert parse_pfx(None) is None
+    assert parse_pfx(1234) is None
+    assert is_valid_pfx(None) is False
+    assert is_valid_pfx(1234) is False
 
 
 def test_invalid_prefixes():
@@ -76,3 +89,15 @@ def test_rir_from_string():
     assert rir_from_str("apnic.db") == "APNIC"
     with pytest.raises(Exception):
         rir_from_str("invalid")
+
+
+def test_get_rpki_thread_count_is_capped(monkeypatch):
+    monkeypatch.setattr("kartograf.util.os.cpu_count", lambda: 128)
+    monkeypatch.setattr("kartograf.util.os.getenv", lambda _key: None)
+    assert get_rpki_thread_count() == 8
+
+
+def test_get_rpki_thread_count_uses_env_override(monkeypatch):
+    monkeypatch.setattr("kartograf.util.os.cpu_count", lambda: 4)
+    monkeypatch.setattr("kartograf.util.os.getenv", lambda key: "2" if key == "RPKI_MAX_THREADS" else None)
+    assert get_rpki_thread_count() == 2


### PR DESCRIPTION
This adds the threaded rpki-client validation path and normalizes threaded/legacy output into one schema before parsing.

Main changes:
1) add backend-specific validation runners (legacy -f batches and threaded -p mode)
2) normalize both output shapes to canonical records (prefix, asn, expires)
3) update parser tie-breaking to deterministic behavior on normalized fields
4) add malformed-output/timeout handling for safer failures
5) add streaming parse dependency support for large RPKI payloads

Why:
issue #93 requires support for rpki-client 9.6 threading, but output shape differs from legacy. Normalization keeps behavior consistent across both backends.

Validation:
-> pytest tests/test_rpki_fetch.py tests/test_rpki_normalize.py tests/test_rpki_parser.py -q
-> pytest -q

Issue linkage:
- addresses #93