### PR TITLE
merge/irr: harden parsing and deterministic output

### DIFF
--- a/kartograf/irr/parse.py
+++ b/kartograf/irr/parse.py
@@ -38,13 +38,20 @@ def parse_irr(context):
 
         # Parse the RPSL objects in the IRR DB into Python Dicts
         for line in lines:
-            if line == '\n':
-                entry_list.append(current_entry)
-                current_entry = {}
-            else:
-                if ":" in line:
-                    k, v = line.strip().split(':', 1)
-                    current_entry[k.strip()] = v.strip()
+            if not line.strip():
+                if current_entry:
+                    entry_list.append(current_entry)
+                    current_entry = {}
+                continue
+
+            if ":" in line:
+                k, v = line.strip().split(':', 1)
+                current_entry[k.strip()] = v.strip()
+
+        # Make sure we don't lose the final object when the file does not end
+        # with a blank line.
+        if current_entry:
+            entry_list.append(current_entry)
 
         for entry in entry_list:
             is_complete = all(k in entry for k in ("origin", "source"))

--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -10,6 +10,8 @@ import pandas as pd
 from kartograf.timed import timed
 from kartograf.util import get_root_network
 
+MAX_MERGE_WORKERS = 4
+
 
 class BaseNetworkIndex:
     '''
@@ -184,7 +186,11 @@ def general_merge(
     df_extra = extra_file_to_df(extra_file)
 
     len_df_extra = len(df_extra)
-    chunk_size = pick_chunk_size(len_df_extra)
+    workers = min(os.cpu_count() or 4, MAX_MERGE_WORKERS)
+    if len_df_extra:
+        workers = min(workers, len_df_extra)
+
+    chunk_size = pick_chunk_size(len_df_extra, workers=workers)
     chunks = []
     chunk_data = []
     for i, row in df_extra.iterrows():
@@ -194,38 +200,39 @@ def general_merge(
             chunk_data = []
 
     all_results = []
-    with ProcessPoolExecutor() as executor:
-        base_dict = base_network_index.get_serializable_dict()
-        futures = [executor.submit(process_chunk_worker, chunk, base_dict) for chunk in chunks]
+    if chunks:
+        with ProcessPoolExecutor(max_workers=workers) as executor:
+            base_dict = base_network_index.get_serializable_dict()
+            futures = [executor.submit(process_chunk_worker, chunk, base_dict) for chunk in chunks]
 
-        for future in futures:
-            all_results.extend(future.result())
+            for future in futures:
+                all_results.extend(future.result())
 
-    # Sort by original index
-    all_results.sort(key=lambda x: x[0])
+        # Sort by original index
+        all_results.sort(key=lambda x: x[0])
 
-    df_extra["INCLUDED"] = [result for _, result in all_results]
+        df_extra["INCLUDED"] = [result for _, result in all_results]
+    else:
+        df_extra["INCLUDED"] = pd.Series(dtype="int64")
 
     df_filtered = df_extra[df_extra.INCLUDED == 0]
 
-    if extra_filtered_file:
-        df_filtered.to_csv(
-            extra_filtered_file,
-            sep=" ",
-            index=False,
-            columns=["PFXS", "ASNS"],
-            header=False,
-        )
-
-        with open(extra_filtered_file, "r") as extra:
-            extra_contents = extra.read()
-    else:
-        extra_contents = df_filtered.to_csv(
-            None, sep=" ", index=False, columns=["PFXS", "ASNS"], header=False
-        )
-
-    with open(base_file, "r") as base:
-        base_contents = base.read()
+    def write_non_empty_lines(src_path, dst_handle):
+        with open(src_path, "r") as src:
+            for line in src:
+                line_without_newline = line.rstrip("\r\n")
+                if line_without_newline.strip():
+                    dst_handle.write(line_without_newline + "\n")
 
     with open(out_file, "w") as merge_file:
-        merge_file.write(base_contents + extra_contents)
+        write_non_empty_lines(base_file, merge_file)
+
+        if extra_filtered_file:
+            with open(extra_filtered_file, "w") as filtered_file:
+                for row in df_filtered.itertuples(index=False):
+                    line = f"{row.PFXS} {row.ASNS}"
+                    filtered_file.write(line + "\n")
+                    merge_file.write(line + "\n")
+        else:
+            for row in df_filtered.itertuples(index=False):
+                merge_file.write(f"{row.PFXS} {row.ASNS}\n")

--- a/tests/test_irr_parse.py
+++ b/tests/test_irr_parse.py
@@ -44,3 +44,34 @@ def test_parse_validation_cases(tmp_path):
 
     # Test expected set
     assert content == ["193.254.30.0/24 AS12726", "212.166.64.0/19 AS12321", "212.80.191.0/24 AS12541", "212.16.0.0/24 AS12346", "212.17.0.0/24 AS12347", "2345:2ca::/32 AS12345" ]
+
+
+def test_parse_irr_handles_missing_trailing_blank_line(tmp_path):
+    context = create_test_context(tmp_path, "111111113")
+    irr_input = Path(context.out_dir_irr) / "ripe_no_trailing.db.route"
+
+    irr_input.write_text(
+        "\n".join(
+            [
+                "route: 1.1.1.0/24",
+                "origin: AS13335",
+                "source: RIPE",
+                "last-modified: 2024-01-01T00:00:00Z",
+                "",
+                "",
+                "route: 8.8.8.0/24",
+                "origin: AS15169",
+                "source: RIPE",
+                "last-modified: 2024-01-02T00:00:00Z",
+            ]
+        ),
+        encoding="ISO-8859-1",
+    )
+
+    parse_irr(context)
+
+    result_file = Path(context.out_dir_irr) / "irr_final.txt"
+    with open(result_file, "r", encoding="utf-8") as f:
+        content = [line.strip() for line in f.readlines()]
+
+    assert content == ["1.1.1.0/24 AS13335", "8.8.8.0/24 AS15169"]

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -133,3 +133,66 @@ def test_pick_chunk_size():
     assert pick_chunk_size(10, workers=4) == 5
     # min_chunk wins
     assert pick_chunk_size(0) == 5
+
+
+def test_merge_output_is_deterministic(tmp_path):
+    data_dir = Path(__file__).parent / "data"
+    base_nets, _ = __read_test_vectors(data_dir / "base_file.csv")
+    extra_nets, _ = __read_test_vectors(data_dir / "extra_file.csv")
+
+    base_path = tmp_path / "base_deterministic.txt"
+    extra_path = tmp_path / "extra_deterministic.txt"
+    out_first = tmp_path / "out_first.txt"
+    out_second = tmp_path / "out_second.txt"
+
+    generate_ip_file(base_path, build_file_lines(base_nets, generate_asns(len(base_nets))))
+    generate_ip_file(extra_path, build_file_lines(extra_nets, generate_asns(len(extra_nets))))
+
+    general_merge(base_path, extra_path, None, out_first)
+    general_merge(base_path, extra_path, None, out_second)
+
+    with open(out_first, "r") as f_first:
+        first_contents = f_first.read()
+    with open(out_second, "r") as f_second:
+        second_contents = f_second.read()
+
+    assert first_contents == second_contents
+
+
+def test_merge_output_is_deterministic_with_filtered_output(tmp_path):
+    data_dir = Path(__file__).parent / "data"
+    base_nets, _ = __read_test_vectors(data_dir / "base_file.csv")
+    extra_nets, _ = __read_test_vectors(data_dir / "extra_file.csv")
+
+    base_path = tmp_path / "base_deterministic_filtered.txt"
+    extra_path = tmp_path / "extra_deterministic_filtered.txt"
+    out_first = tmp_path / "out_first_filtered.txt"
+    out_second = tmp_path / "out_second_filtered.txt"
+    filtered_first = tmp_path / "filtered_first.txt"
+    filtered_second = tmp_path / "filtered_second.txt"
+
+    generate_ip_file(base_path, build_file_lines(base_nets, generate_asns(len(base_nets))))
+    generate_ip_file(extra_path, build_file_lines(extra_nets, generate_asns(len(extra_nets))))
+
+    general_merge(base_path, extra_path, filtered_first, out_first)
+    general_merge(base_path, extra_path, filtered_second, out_second)
+
+    with open(out_first, "r") as f_first:
+        first_contents = f_first.read()
+    with open(out_second, "r") as f_second:
+        second_contents = f_second.read()
+    with open(filtered_first, "r") as f_first_filtered:
+        first_filtered_contents = f_first_filtered.read()
+    with open(filtered_second, "r") as f_second_filtered:
+        second_filtered_contents = f_second_filtered.read()
+
+    assert first_contents == second_contents
+    assert first_filtered_contents == second_filtered_contents
+    assert "\n\n" not in first_contents
+    assert "\n\n" not in second_contents
+    assert "\n\n" not in first_filtered_contents
+    assert "\n\n" not in second_filtered_contents
+    assert all(line.strip() for line in first_contents.splitlines())
+    assert all(line.strip() for line in second_contents.splitlines())
+    assert all(line.strip() for line in first_filtered_contents.splitlines())
+    assert all(line.strip() for line in second_filtered_contents.splitlines())


### PR DESCRIPTION
Small hardening follow-up from regression checks.

Main changes:
1) fix IRR entry splitting for blank-line handling and final-entry flush
2) make merge output writing deterministic and avoid blank-line artifacts
3) cap merge worker count for safer behavior on constrained systems
4) add deterministic merge regression coverage

Validation:
-> pytest tests/test_merge.py tests/test_irr_parse.py -q
-> pytest -q

Issue linkage:
- addresses #138 