### PR TITLE
warn: include detected rpki-client version in compatibility warning

### DIFF
--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -90,7 +90,8 @@ def check_compatibility():
     elif local_version > latest_version:
         print(
             "Warning: This kartograf version has not been tested with "
-            f"rpki-client versions higher than {latest_version}."
+            f"rpki-client versions higher than {latest_version}. "
+            f"You are running rpki-client {local_version}."
         )
     else:
         print(


### PR DESCRIPTION
Just a minor change to tell user which version of rpki-client is running when warning about untested versions. 