### PR TITLE
Bump supported rpki-client version to 9.8

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,6 +1,6 @@
 # Container description file for running kartograf
 FROM python:3.13
-ARG RPKI_VERSION=9.7
+ARG RPKI_VERSION=9.8
 
 # Download and install rpki-client from source
 RUN set -x && \

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ podman rm kartograf-run
 
 #### rpki-client
 
-Kartograf requires `rpki-client` version 9.6 or higher to be installed locally. Many package managers have `rpki-client`, however please note that typically only the latest version is available. Kartograf is currently tested to work with `rpki-client` 9.6 - 9.7. If a new release is available that breaks compatibility, you may need to build a compatible `rpki-client` version yourself if your preferred package manager does not have a compatible version available. In that case, see the [instructions in the rpki-client-portable project](https://github.com/rpki-client/rpki-client-portable/blob/master/INSTALL).
+Kartograf requires `rpki-client` version 9.6 or higher to be installed locally. Many package managers have `rpki-client`, however please note that typically only the latest version is available. Kartograf is currently tested to work with `rpki-client` 9.6 - 9.8. If a new release is available that breaks compatibility, you may need to build a compatible `rpki-client` version yourself if your preferred package manager does not have a compatible version available. In that case, see the [instructions in the rpki-client-portable project](https://github.com/rpki-client/rpki-client-portable/blob/master/INSTALL).
 
 ```
 # Linux/BSD

--- a/flake.lock
+++ b/flake.lock
@@ -32,11 +32,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1768397982,
-        "narHash": "sha256-sXOnoziE74/xFHwVhpOh71xbPmwcgRr1exbrSHvC/A4=",
+        "lastModified": 1776860989,
+        "narHash": "sha256-854I928GfnePjIA05Xl9JQUg9KwbrIjmcupchy1Qqzo=",
         "owner": "asmap",
         "repo": "rpki-client-nix",
-        "rev": "2f7a4dd32ee723e64fa29d98555e2a26867ce36c",
+        "rev": "112cb9b1431430936c37dbbdc3764febc0263a31",
         "type": "github"
       },
       "original": {
@@ -48,34 +48,34 @@
     "rpki-client-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1768329507,
-        "narHash": "sha256-2tZDPAinemEzpV+drJ3LYKG9YA6QmyWFlz+PcT7cwZc=",
+        "lastModified": 1776199275,
+        "narHash": "sha256-PejvnEGr+K+g+vLgO+JroZXRAa1LUJUzCwDVm8AyScY=",
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "f2739829894cfab2711593e41a41dc79410f2d4b",
+        "rev": "15554f28842d7d9e6cc31eab5f95e36053b42f35",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "f2739829894cfab2711593e41a41dc79410f2d4b",
+        "rev": "15554f28842d7d9e6cc31eab5f95e36053b42f35",
         "type": "github"
       }
     },
     "rpki-openbsd-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1768215410,
-        "narHash": "sha256-1H3naG9LjO5wEmEfy5lKt3toDuRlP0o/34jheky91sY=",
+        "lastModified": 1776072166,
+        "narHash": "sha256-sQfoPeWFKQXcaIgEgiCbBrdJ9s1pzXTqz25Y+OH/q4k=",
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "a5a4b737770b3dc586330bbda9f0aeceebfcc961",
+        "rev": "8aa0236d10a6c5e25fb282eb030069dae3d3abbe",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "a5a4b737770b3dc586330bbda9f0aeceebfcc961",
+        "rev": "8aa0236d10a6c5e25fb282eb030069dae3d3abbe",
         "type": "github"
       }
     },

--- a/kartograf/util.py
+++ b/kartograf/util.py
@@ -6,7 +6,7 @@ import re
 import subprocess
 import time
 
-RPKI_VERSION = 9.7
+RPKI_VERSION = 9.8
 
 
 def calculate_sha256(file_path):


### PR DESCRIPTION
I have tested with about 20 runs in different contexts and didn't see any issues.

This is currently still missing the updated flake input.