### PR TITLE
use a tempdir instead of the rpki output dir for rpki-client output

### DIFF
--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -1,6 +1,7 @@
 import re
 import subprocess
 import sys
+from tempfile import TemporaryDirectory
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
@@ -73,35 +74,32 @@ def data_tals(context):
 def fetch_rpki_db(context):
     # Download TALs and presist them in the RPKI data folder
     download_rir_tals(context)
-    tal_options = [item for path in data_tals(context) for item in ('-t', path)]
-    run_args = ["rpki-client", "-d", context.data_dir_rpki_cache,
-                 "-P", context.epoch] + tal_options
-    print("Downloading RPKI Data, this may take a while.")
+    with TemporaryDirectory(prefix="rpki-out-") as tmpdir:
+        tal_options = [item for path in data_tals(context) for item in ('-t', path)]
+        run_args = ["rpki-client", "-m", "-d", context.data_dir_rpki_cache,
+                     "-P", context.epoch] + tal_options
+        print("Downloading RPKI Data, this may take a while.")
 
-    if context.stable_repos:
-        for url in STABLE_REPO_URLS:
-            run_args += ["-H", url]
-        print("Using only stable RPKI repositories.")
+        if context.stable_repos:
+            for url in STABLE_REPO_URLS:
+                run_args += ["-H", url]
+            print("Using only stable RPKI repositories.")
 
-    # rpki-client requires a writable output directory as a positional
-    # argument. Without one it falls back to a compiled-in default that
-    # is not writable in some environments (e.g. nix), which makes it
-    # exit before emitting the CCR hashes.
-    run_args.append(context.out_dir_rpki)
+        run_args += [tmpdir]
 
-    result = subprocess.run(run_args,
-                            capture_output=True,
-                            check=False)
+        result = subprocess.run(run_args,
+                                capture_output=True,
+                                check=False)
 
-    if context.debug_log:
-        with open(context.debug_log, 'a') as logs:
-            logs.write("=== RPKI Download ===\n")
-            if result.stdout:
-                logs.write(result.stdout.decode())
-            if result.stderr:
-                logs.write(result.stderr.decode())
+        if context.debug_log:
+            with open(context.debug_log, 'a') as logs:
+                logs.write("=== RPKI Download ===\n")
+                if result.stdout:
+                    logs.write(result.stdout.decode())
+                if result.stderr:
+                    logs.write(result.stderr.decode())
 
-    parse_ccr_hashes(result.stdout.decode() if result.stdout else "")
+        parse_ccr_hashes(result.stdout.decode() if result.stdout else "")
 
     print(f"Downloaded RPKI Data, hash sum: {calculate_sha256_directory(context.data_dir_rpki_cache)}")
 

--- a/kartograf/rpki/fetch.py
+++ b/kartograf/rpki/fetch.py
@@ -72,7 +72,18 @@ def data_tals(context):
 
 @timed
 def fetch_rpki_db(context):
-    # Download TALs and presist them in the RPKI data folder
+    """
+    rpki-client can take a writable output directory as a positional
+    argument. Without one it falls back to a compiled-in default that
+    is not writable in some environments (e.g. nix).
+    We use python's tempdir, which gets cleaned up automatically.
+    All kartograf output we care about is written to the context.out_dir_rpki.
+
+    We use the '-m' flag to only output metrics to this temporary directory,
+    since the default writes several hundred MB of data. The metrics
+    data is not used.
+    """
+    # Download TALs and persist them in the RPKI data folder
     download_rir_tals(context)
     with TemporaryDirectory(prefix="rpki-out-") as tmpdir:
         tal_options = [item for path in data_tals(context) for item in ('-t', path)]

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -1,6 +1,7 @@
 import json
 import subprocess
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Dict
 
 from kartograf.bogon import (
@@ -122,10 +123,11 @@ def parse_rpki(context):
 
 def compute_ccr_hashes(context):
     """Run rpki-client in offline mode to compute and print CCR hashes."""
-    tal_options = [item for path in data_tals(context) for item in ('-t', path)]
-    run_args = ["rpki-client", "-n", "-d", context.data_dir_rpki_cache,
-                 "-P", context.epoch] + tal_options + [context.out_dir_rpki]
-    result = subprocess.run(run_args,
-                            capture_output=True,
-                            check=False)
-    parse_ccr_hashes(result.stdout.decode() if result.stdout else "")
+    with TemporaryDirectory(prefix="rpki-out-") as tmpdir:
+        tal_options = [item for path in data_tals(context) for item in ('-t', path)]
+        run_args = ["rpki-client", "-m", "-n", "-d", context.data_dir_rpki_cache,
+                     "-P", context.epoch] + tal_options + [tmpdir]
+        result = subprocess.run(run_args,
+                                capture_output=True,
+                                check=False)
+        parse_ccr_hashes(result.stdout.decode() if result.stdout else "")

--- a/kartograf/rpki/parse.py
+++ b/kartograf/rpki/parse.py
@@ -122,7 +122,19 @@ def parse_rpki(context):
 
 
 def compute_ccr_hashes(context):
-    """Run rpki-client in offline mode to compute and print CCR hashes."""
+    """
+    Run rpki-client in offline mode to compute and print CCR hashes.
+
+    rpki-client can take a writable output directory as a positional
+    argument. Without one it falls back to a compiled-in default that
+    is not writable in some environments (e.g. nix).
+    We use python's tempdir, which gets cleaned up automatically.
+    All kartograf output we care about is written to the context.out_dir_rpki.
+
+    We use the '-m' flag to only output metrics to this temporary directory,
+    since the default writes several hundred MB of data. The metrics
+    data is not used.
+    """
     with TemporaryDirectory(prefix="rpki-out-") as tmpdir:
         tal_options = [item for path in data_tals(context) for item in ('-t', path)]
         run_args = ["rpki-client", "-m", "-n", "-d", context.data_dir_rpki_cache,


### PR DESCRIPTION
a by-product of aee081eea07a186657b47e6eb086bc9178cf1bec was the introduction of a writable directory explicitly in the rpki-client run command invocation, which now gets all rpki-client output written to it. This directory is intended for kartograf output, not rpki-client. It seems that systems with writable directories (non-Nix) write this data to a default directory managed by rpki-client, and Nix systems don't write the data at all, failing silently. 

The better solution is to name an explicit, temporary directory for rpki-client output and pass it to the `run` command. The temporary directory is cleaned up automatically after the run finishes.

The `run` command defaults to writing `-joBcm` outputs, but we don't need the output. We add the `-m` flag to the run args, since it limits the output written to the smallest item (metrics, ~330K). 

To summarize: we set an explicit, temporary output directory, we write a tiny bit of data to it, and it gets cleaned up automatically. 