### PR TITLE
check prefixlen in check_inclusion

### DIFF
--- a/kartograf/merge.py
+++ b/kartograf/merge.py
@@ -41,17 +41,19 @@ class BaseNetworkIndex:
 
         if (root_net in self._v4_keys) or (root_net in self._v6_keys):
             current = self._dict[v][root_net]
-            self._dict[v][root_net] = current + [(netw, mask)]
+            self._dict[v][root_net] = current + [(netw, mask, ipn.prefixlen)]
         else:
-            self._dict[v].update({root_net: [(netw, mask)]})
+            self._dict[v].update({root_net: [(netw, mask, ipn.prefixlen)]})
 
     def check_inclusion(self, row, root_net, version):
         """
         A network is a subnet of another if the bitwise AND of its IP and the base network's netmask
-        is equal to the base network IP.
+        is equal to the base network IP, and the network's prefix length is larger or equal than the base network's
+        prefix length.
         """
-        for net, mask in self._dict[version][root_net]:
-            if row.INETS & mask == net:
+        candidate = ipaddress.ip_network(row.PFXS)
+        for net, mask, prefixlen in self._dict[version][root_net]:
+            if candidate.prefixlen >= prefixlen and row.INETS & mask == net:
                 return 1
         return 0
 

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -126,6 +126,41 @@ def test_merge_rpki_supersedes_irr_subnets(tmp_path):
         f"IRR subnets should not appear in merged output: {set(final_ips) & set(irr_ips)}"
     )
 
+def test_more_specific_base_does_not_suppress_extra_supernet(tmp_path):
+    '''
+    Test that a base more-specific prefix does not suppress an extra supernet
+    with the same network address.
+    A more specific network should not supersede a less specific network merged first.
+    In this test, 12.2.12.0/24 should not be merged since it is more specific than
+    12.0.0.0/8 and /9.
+    '''
+    rpki_path = tmp_path / "rpki_final.txt"
+    irr_path = tmp_path / "irr_final.txt"
+    rv_path = tmp_path / "pfx2asn_clean.txt"
+    merged_rpki_irr_path = tmp_path / "merged_file_rpki_irr.txt"
+    final_path = tmp_path / "merged_file_rpki_irr_rv.txt"
+
+    rpki_path.write_text("12.0.0.0/22 AS6269\n")
+    irr_path.write_text("12.0.0.0/8 AS7018\n12.0.0.0/9 AS7018\n")
+    rv_path.write_text("12.2.12.0/24 AS40724\n13.0.0.0/8 AS1239\n")
+
+    general_merge(rpki_path, irr_path, None, merged_rpki_irr_path)
+    general_merge(merged_rpki_irr_path, rv_path, None, final_path)
+
+    merged_rpki_irr = merged_rpki_irr_path.read_text()
+    final_result = final_path.read_text()
+
+    assert "12.0.0.0/22 AS6269\n" in merged_rpki_irr
+    assert "12.0.0.0/8 AS7018\n" in merged_rpki_irr
+    assert "12.0.0.0/9 AS7018\n" in merged_rpki_irr
+
+    assert "12.0.0.0/22 AS6269\n" in final_result
+    assert "12.0.0.0/8 AS7018\n" in final_result
+    assert "12.0.0.0/9 AS7018\n" in final_result
+    assert "12.2.12.0/24 AS40724\n" not in final_result
+    assert "13.0.0.0/8 AS1239\n" in final_result
+
+
 def test_pick_chunk_size():
     '''
     Test picking a chunk size for the merge function.


### PR DESCRIPTION
When merging in a map (such as IRR into RPKI), a more specific prefix should not supersede a less specific network. This adds a check on the prefix length of the network, which returns check_inclusion = True only if the networks match and the prefix length is greater (edit: or equal to) ~than~ the existing one.

The diff from the [1780588800](https://github.com/bitcoin-core/asmap-data/issues/51) run with the same data sources yields 16856 lines, the majority of which are un-assignments, i.e. many networks that were previously merged in due to the current check_inclusion are no longer assigned, as expected.

This is backwards incompatible, in the sense that given a same input, the output ASmap will be different if this is merged in.

Closes #144 