### PR TITLE
Bump version to 0.5.0, fix CI

### DIFF
--- a/.github/workflows/test-reproduction-run.yml
+++ b/.github/workflows/test-reproduction-run.yml
@@ -37,5 +37,5 @@ jobs:
         output=$(nix develop --command ./run map -r tests/data/1762444800 -t 1762444800 2>&1)
         echo "$output"
 
-        echo "$output" | grep -q '8dec174852e3dad0854d41319f60dad03b017c61e822680bf9c3f8fd3ea8fc6d'
+        echo "$output" | grep -q 'b74e6f77817674e3b05232dee8153cf886e96887bd6321aa5028d6ed7ca96cac'
         echo "Output matches the expected value"

--- a/kartograf/__init__.py
+++ b/kartograf/__init__.py
@@ -1,3 +1,3 @@
 __author__ = "Fabian Jahr"
-__version__ = "0.4.13"
+__version__ = "0.5.0"
 __license__ = "MIT"


### PR DESCRIPTION
After merges of #145 and #148 are breaking reproducibility we need to fix the CI since the reproducibility job currently fails and release a new version. More communication coming on this shortly.